### PR TITLE
Fix: 회원가입 및 로그인 코드 수정

### DIFF
--- a/src/common/createError.ts
+++ b/src/common/createError.ts
@@ -1,4 +1,4 @@
-class  RegExpError extends Error {
+class RegExpError extends Error {
   private statusCode: number
 
   constructor(message: string) {
@@ -6,7 +6,17 @@ class  RegExpError extends Error {
     this.name = "Regular Expresstion Error"
     this.statusCode = 400
   }
+}
+
+class keyError extends Error {
+  private statusCode: number
+
+  constructor(message: string) {
+    super(message)
+    this.name = "Duplication Check Key Error"
+    this.statusCode = 400
   }
+}
 
 class NotFoundError extends Error {
   private statusCode: number
@@ -39,4 +49,4 @@ class PwMismatchError extends Error {
 }
 
 
-export { RegExpError, NotFoundError, DuplicateError, PwMismatchError }
+export { RegExpError, keyError, NotFoundError, DuplicateError, PwMismatchError }

--- a/src/common/keyErrorCheck.ts
+++ b/src/common/keyErrorCheck.ts
@@ -2,7 +2,7 @@ import { UserDTO } from "../dto/userDto"
 import { RegExpError } from "./createError"
 
 export const keyError = (userData: UserDTO) => {
-  const accountRegex = /^[\da-zA-Z]{1,12}$/g
+  const accountRegex = /^[\da-zA-Z]{6,15}$/g
   const passwordRegex = /^(?=.*\d)(?=.*[a-zA-Z])(?=.*[@#*!^])[\da-zA-Z@#*!^]{8,16}$/g
   const nicknameRegex = /^[a-zA-z0-9.\-_!?^()/@#*!^ㄱ-ㅎ|ㅏ-ㅣ|가-힣]{1,8}$/g
   

--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -27,7 +27,7 @@ const signInUser = asyncWrap (async (req: Request, res: Response) => {
   const userData: UserDTO = req.body;
 
   const result = await userService.signInUser(userData);
-  res.status(201).json({ message: "Login_Success", result });
+  res.status(200).json({ message: "Login_Success", result });
 });
 
 

--- a/src/models/userDao.ts
+++ b/src/models/userDao.ts
@@ -29,12 +29,14 @@ const createUser = async (userData: UserDTO): Promise<object> => {
 }
 
 
-const getUserByAccount = async (selectQuery: string): Promise<any> => {
+const getUserByAccount = async (userData: UserDTO): Promise<any> => {
+  const account = userData.account;
+
   return await myDataSource.query(`
     SELECT 
       id, password, nickname 
     FROM users 
-    WHERE ${selectQuery}`)
+    WHERE account = ?`, [account])
 }
 
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import { createApp } from "./app";
 
 const app = createApp();
 
-const PORT = process.env.PORT || 8000;
+const PORT = process.env.PORT;
 
 app.listen(PORT, () => {
   console.log(`Server start : http://localhost:${PORT}..`);


### PR DESCRIPTION
회원가입 및 로그인 코드 수정
  - 계정 및 이메일 중복 체크 함수의 쿼리 변수 및 조건 수정
  - 중복 체크 시 key에 대한 사용자 정의 에러 createError에 추가, 적용
  - 계정 정규표현식 제한 길이 변경
  - 로그인 응답 status code 200으로 변경
  - service단 로그인 함수의 반환 값 수정
  - model단 로그인 함수 쿼리 수정

Issue: #5