### PR TITLE
Feature: 카카오 로그인, 로그아웃 추가

### DIFF
--- a/src/common/createError.ts
+++ b/src/common/createError.ts
@@ -1,3 +1,13 @@
+class BadRequestExceptions extends Error {
+  private statusCode: number
+
+  constructor(message: string) {
+    super(message)
+    this.name = "Bad Request"
+    this.statusCode = 400
+  }
+}
+
 class RegExpError extends Error {
   private statusCode: number
 
@@ -49,4 +59,11 @@ class PwMismatchError extends Error {
 }
 
 
-export { RegExpError, keyError, NotFoundError, DuplicateError, PwMismatchError }
+export { 
+  BadRequestExceptions,
+  RegExpError,
+  keyError,
+  NotFoundError,
+  DuplicateError,
+  PwMismatchError
+}

--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -3,6 +3,7 @@ import { asyncWrap } from "../common/asyncWrap"
 import { keyError } from "../common/keyErrorCheck";
 import { UserDTO } from "../dto/userDto"
 import userService from "../services/userService"
+import { BadRequestExceptions } from "../common/createError"
 
 
 
@@ -31,5 +32,27 @@ const signInUser = asyncWrap (async (req: Request, res: Response) => {
 });
 
 
+const kakaoLogin = asyncWrap (async (req: Request, res: Response) => {
+  const authorizeCode = req.body;
 
-export default { userAvailableCheck, createUser, signInUser }
+  if(!authorizeCode) { throw new BadRequestExceptions("Require_Kakao_Login"); }
+
+  const userInfo = await userService.kakaoLogin(authorizeCode);
+  res.status(200).json(userInfo)
+});
+
+
+const kakaoLogout = asyncWrap (async (req: Request, res: Response) => {
+  const result = await userService.kakaoLogout();
+  if(result.status === 200) res.status(200).json({ message: "Logout_Success" })
+})
+
+
+
+export default { 
+  userAvailableCheck,
+  createUser,
+  signInUser,
+  kakaoLogin,
+  kakaoLogout
+}

--- a/src/models/userDao.ts
+++ b/src/models/userDao.ts
@@ -40,6 +40,36 @@ const getUserByAccount = async (userData: UserDTO): Promise<any> => {
 }
 
 
+const createSNSUser = async (account: string, email: string, nickname: string): Promise<object> => {
+  return await myDataSource
+  .createQueryBuilder()
+  .insert()
+  .into(Users)
+  .values({
+    account,
+    password: "",
+    nickname,
+    email
+  })
+  .execute()
+}
 
 
-export default { getUserExists, createUser, getUserByAccount }
+const getSNSUser = async (account: string, email: string) => {// 인자로 email 올 수 있는 거 맞아?
+  return await myDataSource.query(`
+  SELECT 
+    id, email, nickname 
+  FROM users 
+  WHERE email = ? AND account = ?`, [email, account]) // DB명 변경 주의
+}
+
+
+
+
+export default { 
+  getUserExists,
+  createUser,
+  getUserByAccount,
+  createSNSUser,
+  getSNSUser
+}

--- a/src/routes/usersRoute.ts
+++ b/src/routes/usersRoute.ts
@@ -6,5 +6,8 @@ const router = express.Router()
 router.post('/duplication', userController.userAvailableCheck)
 router.post('/signup', userController.createUser)
 router.post('/signin', userController.signInUser)
+router.post('/kakaoLogin', userController.kakaoLogin)
+router.post('/kakaoLogout', userController.kakaoLogout) // 굳이 카카오와 일반 로그아웃을 구별?
+
 
 export default router

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,9 +1,10 @@
+import axios, { AxiosResponse } from "axios";
 import bcrypt from "bcryptjs"
 import jwt from "jsonwebtoken"
 import userDao from "../models/userDao"
 import { UserDTO } from "../dto/userDto"
-import { keyError, PwMismatchError } from "../common/createError"
-import { SECRET_KEY } from "../configs/keyConfig"
+import { BadRequestExceptions, keyError, PwMismatchError } from "../common/createError"
+import { SECRET_KEY, JavaScript_Key, REDIRECT_URI } from "../configs/keyConfig"
 
 
 const userAvailableCheck = async (userData: object) => {
@@ -38,12 +39,90 @@ const signInUser = async (userData: UserDTO) => {
   
   const user = {
     nickname: userIdPw[0].nickname,
-    token: token
+    token
   }
 
   return user;
 }
 
 
+// kakao
+let accessToken: AxiosResponse<any, any>;
 
-export default { userAvailableCheck, createUser, signInUser }
+const getTokenByAuthorizeCode = async (authorizeCode: any) => {
+  return axios({
+    method: "POST",
+    url: "https://kauth.kakao.com/oauth/token",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+    },
+    params: {
+      "grant_type": "authorization_code",
+      "client_id": JavaScript_Key,
+      "redirect_uri": REDIRECT_URI,
+      "code": authorizeCode.authorizationCode
+    }
+  })
+}
+
+const getUserInfoByKakaoToken = (kakaoToken: string) => {
+  return axios({
+    method: "GET",
+    url: "https://kapi.kakao.com/v2/user/me",
+    headers: {
+      Authorization: `Bearer ${kakaoToken}`
+    }
+  })
+}
+
+const kakaoLogin = async (authorizeCode: any) => {
+  const kakaoToken = await getTokenByAuthorizeCode(authorizeCode); // object type
+  
+  // if(kakaoToken.status === 400) { throw new BadRequestExceptions("Bad Request") }
+  const userInfo = await getUserInfoByKakaoToken(kakaoToken.data.access_token); // object type
+  
+  const account = "KAKAO";
+  const foundUser = await userDao.getSNSUser(account, userInfo.data.kakao_account.email);
+
+  
+  if(foundUser.length === 0) { 
+    await userDao.createSNSUser(
+      account,
+      userInfo.data.kakao_account.email,
+      userInfo.data.kakao_account.profile.nickname
+  ); }
+
+  const user = await userDao.getSNSUser(account, userInfo.data.kakao_account.email);
+  const token = jwt.sign({ id: user[0].id }, SECRET_KEY, { expiresIn: '2h' });
+  
+  const result = {
+    nickname: userInfo.data.kakao_account.profile.nickname,
+    token
+  }
+
+  accessToken = kakaoToken;
+  return result;
+}
+
+
+const kakaoLogout = () => {
+  console.log(accessToken)
+  return axios({
+      method: "POST",
+      url: "https://kapi.kakao.com/v1/user/logout",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+        Authorization: `Bearer ${accessToken}`
+      }
+  })
+}
+
+
+
+export default { 
+  userAvailableCheck,
+  createUser,
+  signInUser,
+  kakaoLogin,
+  kakaoLogout
+}


### PR DESCRIPTION
카카오 로그인, 로그아웃 추가
  - 카카오 로그인을 위해 토큰 발급, 사용자 정보 조회하는 로직 추가
  - axios를 활용하여 POST, GET HTTP 통신
  - 프론트엔드로부터 인가 코드가 전달되지 않았을 경우 적절한 예외처리
  - 발급받은 토큰으로 얻은, 사용자 정보로 DB 존재 유무 확인 > 없을 경우 유저 추가
  - 카카오 토큰이 아닌, jwt를 이용한 토큰 발행 및 전달
  - 로그아웃(미완) 추가

Issue: #6