### PR TITLE
Feature: 메인, 상세 게시글의 좋아요 기능 추가

### DIFF
--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -13,19 +13,39 @@ const createPost = asyncWrap (async (req: Request, res: Response) => {
   res.status(201).json({ message: "Post_Created" })
 })
 
+
 const getAllPosts = asyncWrap (async (req: Request, res: Response) => {
-  const posts = await postService.getAllPosts();
+  const userId: number | null = req.body.foundUser;
+
+  const posts = await postService.getAllPosts(userId);
   res.status(200).json(posts)
 })
 
+
 const getPostById = asyncWrap (async (req: Request, res: Response) => {
+  const userId: number | null = req.body.foundUser;
   let postId = req.params.post_id;
   let numPostId = +postId;
 
-  const post = await postService.getPostById(numPostId);
+  const post = await postService.getPostById(userId, numPostId);
   res.status(200).json(post)
 })
 
 
+const updatePostLikeByUser = asyncWrap (async (req: Request, res: Response) => {
+  const userId= req.body.foundUser;
+  const postId = req.params.post_id;
+  const numPostId = +postId;
 
-export default { createPost, getAllPosts, getPostById }
+  const state = await postService.updatePostLikeByUser(userId, numPostId)
+  res.status(200).json(state)
+})
+
+
+
+export default { 
+  createPost,
+  getAllPosts,
+  getPostById,
+  updatePostLikeByUser
+}

--- a/src/middlewares/authorization.ts
+++ b/src/middlewares/authorization.ts
@@ -27,5 +27,27 @@ const validateToken = async (req: Request, res: Response, next: NextFunction) =>
 };
 
 
+const validateTokenBycondition = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const access_token = req.headers['authorization'];
+    if(access_token) {
+      const userId = jwt.verify(access_token, SECRET_KEY);
+      const value = Object.values(userId)
+      
+      const [foundUser] = await getUserExistsById(value[0]);
+      if(!+Object.values(foundUser)[0]) throw new NotFoundError("User_Not_Found");
+      
+      req.body.foundUser = value[0];
+    } else if (!access_token) { req.body.foundUser = null; }
 
-export { validateToken };
+    next();
+
+  } catch (error) {
+    console.log(error)
+    throw new BadRequestExceptions("Invalid_Token")
+  }
+};
+
+
+
+export { validateToken, validateTokenBycondition };

--- a/src/models/postDao.ts
+++ b/src/models/postDao.ts
@@ -1,6 +1,7 @@
 import { myDataSource } from "../configs/typeorm_config";
 import { PostDTO } from "../dto/postDto";
 import { Posts } from "../entities/post_entity";
+import { Post_likes } from "../entities/post_likes_entity";
 
 
 
@@ -17,35 +18,97 @@ const createPost = async (categoryId: number, postData: PostDTO): Promise<void> 
 }
 
 
-// 토큰 유무에 따라 좋아요, 북마크 표시 필요
+const getAllPosts = async (userId: number | null): Promise<object[]> => {
+  let query = ""
+  let select = ""
 
-const getAllPosts = async (): Promise<object[]> => {
+  if(userId != null) {
+  select = `, likes.is_liked as is_liked`
+  query = `LEFT JOIN (SELECT post_id, is_liked FROM post_likes WHERE user_id = ${userId}) likes ON p.id = likes.post_id`
+  }
+
   return await myDataSource.query(`
     SELECT 
       p.id, u.nickname, p.user_id, cate.name as category, p.category_id,
       p.content, p.created_at, c.count_comments, pl.count_likes
+      ${select}
     FROM posts p
     JOIN users u ON p.user_id = u.id
     JOIN categories cate ON p.category_id = cate.id
+    ${query}
     LEFT JOIN (SELECT post_id, COUNT(id) as count_comments FROM comments GROUP BY post_id) c ON p.id = c.post_id
-    LEFT JOIN (SELECT post_id, COUNT(id) as count_likes FROM post_likes GROUP BY post_id) pl ON p.id = pl.post_id 
+    LEFT JOIN (SELECT post_id, COUNT(id) as count_likes FROM post_likes WHERE is_liked = 1 GROUP BY post_id) pl ON p.id = pl.post_id 
     ORDER BY p.created_at DESC`)
 }
 
 
-const getPostById = async (postId: number): Promise<object> => {
+const getPostById = async (userId: number | null, postId: number): Promise<object> => {
+  let query = ""
+  if(userId !== null) {
+  query = `, (SELECT is_liked FROM post_likes WHERE user_id = ${userId} AND post_id = ${postId}) as is_liked`
+  }
+
   return await myDataSource.query(`
     SELECT 
       p.id, u.nickname, p.user_id, cate.name as category, p.category_id,
       p.content, p.created_at, c.count_comments, pl.count_likes
+      ${query}
     FROM posts p
     JOIN users u ON p.user_id = u.id
     JOIN categories cate ON p.category_id = cate.id
     LEFT JOIN (SELECT post_id, COUNT(id) as count_comments FROM comments GROUP BY post_id) c ON p.id = c.post_id
-    LEFT JOIN (SELECT post_id, COUNT(id) as count_likes FROM post_likes GROUP BY post_id) pl ON p.id = pl.post_id 
+    LEFT JOIN (SELECT post_id, COUNT(id) as count_likes FROM post_likes WHERE is_liked = 1 GROUP BY post_id) pl ON p.id = pl.post_id 
     WHERE p.id = ?
   `, [postId]);
 }
 
 
-export default { createPost, getAllPosts, getPostById }
+const getPostLikesByUserPostId = async(userId: number, postId: number) => {
+  return await myDataSource.query(`SELECT EXISTS (SELECT id FROM post_likes WHERE user_id = ? AND post_id = ?) as Exist`, [userId, postId])
+}
+
+const insertPostLikes = async(userId: number, postId: number) => {
+  return await myDataSource.createQueryBuilder()
+  .insert()
+  .into(Post_likes)
+  .values({
+    user_id: userId,
+    post_id: postId,
+    is_liked: "1"
+  })
+  .execute()
+}
+
+
+const updatePostLikeByUser = async(userId: number, postId: number) => {
+  await myDataSource.query(`
+    UPDATE post_likes
+    SET is_liked =
+      CASE
+        WHEN is_liked = 0 THEN 1
+        WHEN is_liked = 1 THEN 0
+      END
+    WHERE user_id = ? AND post_id = ?
+  `, [userId, postId])
+}
+
+
+const getPostLike = async(userId: number, postId: number) => {
+  return await myDataSource.query(`
+    SELECT 
+      is_liked,
+      (SELECT COUNT(id) FROM post_likes WHERE post_id = ? AND is_liked = 1 GROUP BY post_id) as count_likes
+    FROM post_likes WHERE user_id = ? AND post_id = ?  
+  `, [postId, userId, postId])
+}
+
+
+export default { 
+  createPost,
+  getAllPosts,
+  getPostById,
+  getPostLikesByUserPostId,
+  insertPostLikes,
+  updatePostLikeByUser,
+  getPostLike
+}

--- a/src/routes/postsRoute.ts
+++ b/src/routes/postsRoute.ts
@@ -1,11 +1,12 @@
 import express from "express"
 import postController from "../controllers/postController"
-import { validateToken } from "../middlewares/authorization"
+import { validateToken, validateTokenBycondition } from "../middlewares/authorization"
 
 const router = express.Router()
 
 router.post("", validateToken, postController.createPost)
-router.get("", postController.getAllPosts)
-router.get("/:post_id", postController.getPostById)
+router.get("", validateTokenBycondition, postController.getAllPosts)
+router.get("/:post_id", validateTokenBycondition, postController.getPostById)
+router.patch("/:post_id/like", validateToken, postController.updatePostLikeByUser)
 
 export default router

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -7,13 +7,30 @@ const createPost = async (categoryId: number, postData: PostDTO) => {
   await postDao.createPost(categoryId, postData);
 }
 
-const getAllPosts = async () => {
-  return await postDao.getAllPosts();
+const getAllPosts = async (userId: number | null) => {
+  return await postDao.getAllPosts(userId);
 }
 
-const getPostById = async (postId: number) => {
-  return await postDao.getPostById(postId)
+const getPostById = async (userId: number | null, postId: number) => {
+  return await postDao.getPostById(userId, postId)
+}
+
+const updatePostLikeByUser = async(userId: number, postId: number) => {
+  const [isLiked] = await postDao.getPostLikesByUserPostId(userId, postId);
+  
+  if(isLiked.Exist === "0") { 
+    await postDao.insertPostLikes(userId, postId)
+    return await postDao.getPostLike(userId, postId) }
+
+  else if(isLiked.Exist === "1") { 
+    await postDao.updatePostLikeByUser(userId, postId)
+    return await postDao.getPostLike(userId, postId) }
 }
 
 
-export default { createPost, getAllPosts, getPostById }
+export default { 
+  createPost,
+  getAllPosts,
+  getPostById,
+  updatePostLikeByUser
+}


### PR DESCRIPTION
메인, 상세 게시글의 좋아요 기능 추가
  - 메인, 상세 게시글 조회할 때 로그인 여부에 따라 좋아요 여부 표시
  - 로그인 여부에 따라 좋아요 여부를 반환할 수 있도록 새로운 인증인가 함수 추가
  - 토큰이 있다면 user의 고유키 값을, 토큰이 없는 경우 null을 반환
  - null일 경우, 로그인하지 않았다고 판단하여 게시글 조회시 좋아요 여부 반환 안함(수 COUNT는 반환)
  - 고유키 값의 경우, 해당 유저가 좋아요 누른 게시글에 한해 좋아요 여부 반환
  - 로그인한 유저가 특정 게시글에 좋아요를 누를 때, 처음 누른 경우 해당 데이터가 post_likes 테이블에 저장
  - 기존에 좋아요를 눌렀던 적 있는 경우, CASE WHEN 조건문에 따라 0에서 1, 1에서 0으로 is_liked 값이 수정
  - 수정된 값에 따라 좋아요 수 COUNT 값도 변동

Issue: #14 #19