### PR TITLE
Feature: 게시글 북마크 기능 추가

### DIFF
--- a/src/configs/typeorm_config.ts
+++ b/src/configs/typeorm_config.ts
@@ -1,6 +1,7 @@
 import { DataSource } from "typeorm"
 import { Categories } from "../entities/category_entity";
 import { Comments } from "../entities/comments_entity";
+import { Post_bookmarks } from "../entities/post_bookmarks_entity";
 import { Posts } from "../entities/post_entity";
 import { Post_images } from "../entities/post_images_entity";
 import { Post_likes } from "../entities/post_likes_entity";
@@ -13,7 +14,7 @@ const myDataSource = new DataSource ({
   username: process.env.TYPEORM_USERNAME,
   password: process.env.TYPEORM_PASSWORD,
   database: process.env.TYPEORM_DATABASE,
-  entities: [Categories ,Users, Posts, Post_likes, Post_images, Comments],
+  entities: [Categories ,Users, Posts, Post_likes, Post_images, Comments, Post_bookmarks],
   synchronize: true,
   logging: true
 });

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -57,6 +57,15 @@ const updatePostLikeByUser = asyncWrap (async (req: Request, res: Response) => {
 })
 
 
+const updatePostBookmark = asyncWrap (async (req: Request, res: Response) => {
+  const userId= req.body.foundUser;
+  const postId = +req.params.post_id;
+
+  const state = await postService.updatePostBookmark(userId, postId)
+  res.status(200).json(state)
+})
+
+
 
 
 export default { 
@@ -65,5 +74,6 @@ export default {
   getPostById,
   updatePost,
   deletePost,
-  updatePostLikeByUser
+  updatePostLikeByUser,
+  updatePostBookmark
 }

--- a/src/entities/post_bookmarks_entity.ts
+++ b/src/entities/post_bookmarks_entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm"
+import { Posts } from "./post_entity";
+import { Users } from "./user_entity";
+
+@Entity('post_bookmarks')
+export class Post_bookmarks {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("int")
+  user_id!: number;
+
+  @Column("int")
+  post_id!: number;
+
+  @Column("char", { length: 1 })
+  is_marked!: string;
+
+  @ManyToOne(() => Users, (user) => user.post_bookmarks, {onDelete: 'CASCADE'} )
+  @JoinColumn({ name: "user_id", referencedColumnName: 'id' })
+  user!: Users;
+
+  @ManyToOne(() => Posts, (post) => post.post_bookmarks, {onDelete: 'CASCADE'} )
+  @JoinColumn({ name: "post_id", referencedColumnName: 'id' })
+  post!: Posts;
+}

--- a/src/entities/post_entity.ts
+++ b/src/entities/post_entity.ts
@@ -1,9 +1,10 @@
-import { BaseEntity, Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm"
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm"
 import { Categories } from "./category_entity";
 import { Comments } from "./comments_entity";
 import { Post_images } from "./post_images_entity";
 import { Post_likes } from "./post_likes_entity";
 import { Users } from "./user_entity";
+import { Post_bookmarks } from "./post_bookmarks_entity";
 
 @Entity('posts')
 export class Posts {
@@ -48,4 +49,7 @@ export class Posts {
 
   @OneToMany(() => Post_images, (post_image) => post_image.post, {cascade: true} )
   post_images!: Post_images[];
+
+  @OneToMany(() => Post_bookmarks, (post_bookmark) => post_bookmark.post, {cascade: true} )
+  post_bookmarks!: Post_bookmarks[];
 }

--- a/src/entities/user_entity.ts
+++ b/src/entities/user_entity.ts
@@ -1,5 +1,6 @@
 import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from "typeorm"
 import { Comments } from "./comments_entity";
+import { Post_bookmarks } from "./post_bookmarks_entity";
 import { Posts } from "./post_entity";
 
 @Entity('users')
@@ -40,4 +41,7 @@ export class Users {
 
   @OneToMany(() => Posts, (post_like) => post_like.user)
   post_likes!: Posts[];
+
+  @OneToMany(() => Post_bookmarks, (post_bookmark) => post_bookmark.user, {cascade: true} )
+  post_bookmarks!: Post_bookmarks[];
 }

--- a/src/models/postBookmarks.ts
+++ b/src/models/postBookmarks.ts
@@ -1,0 +1,52 @@
+import { myDataSource } from "../configs/typeorm_config";
+import { Post_bookmarks } from "../entities/post_bookmarks_entity";
+
+
+
+const getPostBookmarkByUserPostId = async(userId: number, postId: number) => {
+  return await myDataSource.query(`SELECT EXISTS (SELECT id FROM post_bookmarks WHERE user_id = ? AND post_id = ?) as Exist`, [userId, postId])
+}
+
+
+const insertPostBookmarks = async(userId: number, postId: number): Promise<void> => {
+  await myDataSource.createQueryBuilder()
+  .insert()
+  .into(Post_bookmarks)
+  .values({
+    user_id: userId,
+    post_id: postId,
+    is_marked: "1"
+  })
+  .execute()
+}
+
+
+const updatePostBookmark = async(userId: number, postId: number): Promise<void> => {
+  await myDataSource.query(`
+    UPDATE post_bookmarks
+    SET is_marked =
+      CASE
+        WHEN is_marked = 0 THEN 1
+        WHEN is_marked = 1 THEN 0
+      END
+    WHERE user_id = ? AND post_id = ?
+  `, [userId, postId])
+}
+
+
+const getPostBookmark = async(userId: number, postId: number) => {
+  return await myDataSource.query(`
+    SELECT 
+      is_marked
+    FROM post_bookmarks WHERE user_id = ? AND post_id = ?  
+  `, [userId, postId])
+}
+
+
+
+export default {
+  getPostBookmarkByUserPostId,
+  insertPostBookmarks,
+  updatePostBookmark,
+  getPostBookmark
+}

--- a/src/routes/postsRoute.ts
+++ b/src/routes/postsRoute.ts
@@ -10,5 +10,6 @@ router.get("/:post_id", validateTokenBycondition, postController.getPostById)
 router.patch("/:post_id", validateToken, postController.updatePost)
 router.delete("/:post_id", validateToken, postController.deletePost)
 router.patch("/:post_id/like", validateToken, postController.updatePostLikeByUser)
+router.patch("/:post_id/bookmark", validateToken, postController.updatePostBookmark)
 
 export default router

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -1,4 +1,5 @@
 import { CreatePostDTO, UpdatePostDTO } from "../dto/postDto";
+import postBookmarks from "../models/postBookmarks";
 import postDao from "../models/postDao";
 
 
@@ -63,11 +64,32 @@ const updatePostLikeByUser = async(userId: number, postId: number) => {
 }
 
 
+const updatePostBookmark = async(userId: number, postId: number) => {
+  const [isMarked] = await postBookmarks.getPostBookmarkByUserPostId(userId, postId);
+
+  switch(isMarked.Exist) { 
+    case "0" :
+      await postBookmarks.insertPostBookmarks(userId, postId)
+      const [case0] = await postBookmarks.getPostBookmark(userId, postId)
+      case0.is_marked = +case0.is_marked;
+      return case0;
+
+    case "1" : 
+      await postBookmarks.updatePostBookmark(userId, postId)
+      const [case1] = await postBookmarks.getPostBookmark(userId, postId)
+      case1.is_marked = +case1.is_marked;
+      return case1;
+    }
+} 
+
+
+
 export default { 
   createPost,
   getAllPosts,
   getPostById,
   updatePost,
   deletePost,
-  updatePostLikeByUser
+  updatePostLikeByUser,
+  updatePostBookmark
 }


### PR DESCRIPTION
게시글 북마크 기능 추가
  - 북마크 entity(post_bookmarks) 생성 및 onDelete 옵션 추가
  - 메인, 상세 게시글 조회할 때 로그인 여부에 따라 북마크 여부(is_marked) 표시
  - 로그인 했을 경우, 해당 유저가 북마크한 게시글에 is_marked = 0 또는 1 반환
  - 북마크 버튼을 한번도 누른 적 없는 게시글에는 null로 표시
  - 로그인한 유저가 특정 게시글을 북마크할 때, 북마크 테이블을 user_id, post_id로 조회하여 Exist 확인
  - Exist가 0인 경우, 해당 데이터를 북마크 테이블에 저장(user_id, post_id, is_makred = 1)
  - Exist가 1인 경우, CASE WHEN 조건문에 따라 0에서 1, 1에서 0으로 is_marked 값이 수정
  - 응답으로 반환되는 is_makred 값을 string에서 number로 바꿔주는 코드 service단에 작성

Issue: #23