### PR TITLE
Fix: entities 오류 수정 및 onDelete 옵션 수정, 게시글 좋아요 코드 수정

### DIFF
--- a/src/entities/post_entity.ts
+++ b/src/entities/post_entity.ts
@@ -44,7 +44,7 @@ export class Posts {
   @OneToMany(() => Comments, (comment) => comment.post )
   comments!: Comments[];
 
-  @OneToMany(() => Post_likes, (post_like) => post_like.post )
+  @OneToMany(() => Post_likes, (post_like) => post_like.post, {cascade: true} )
   post_likes!: Post_likes[];
 
   @OneToMany(() => Post_images, (post_image) => post_image.post, {cascade: true} )

--- a/src/entities/post_likes_entity.ts
+++ b/src/entities/post_likes_entity.ts
@@ -16,11 +16,11 @@ export class Post_likes {
   @Column("char", { length: 1 })
   is_liked!: string;
 
-  @ManyToOne(() => Users, (user) => user.post_likes )
+  @ManyToOne(() => Users, (user) => user.post_likes, {onDelete: 'CASCADE'} )
   @JoinColumn({ name: "user_id", referencedColumnName: 'id' })
   user!: Users;
 
-  @ManyToOne(() => Posts, (post) => post.post_likes )
+  @ManyToOne(() => Posts, (post) => post.post_likes, {onDelete: 'CASCADE'} )
   @JoinColumn({ name: "post_id", referencedColumnName: 'id' })
   post!: Posts;
 }

--- a/src/entities/user_entity.ts
+++ b/src/entities/user_entity.ts
@@ -2,6 +2,7 @@ import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn, CreateDa
 import { Comments } from "./comments_entity";
 import { Post_bookmarks } from "./post_bookmarks_entity";
 import { Posts } from "./post_entity";
+import { Post_likes } from "./post_likes_entity";
 
 @Entity('users')
 export class Users {
@@ -39,8 +40,8 @@ export class Users {
   @OneToMany(() => Comments, (comment) => comment.user)
   comments!: Comments[];
 
-  @OneToMany(() => Posts, (post_like) => post_like.user)
-  post_likes!: Posts[];
+  @OneToMany(() => Post_likes, (post_like) => post_like.user, {cascade: true})
+  post_likes!: Post_likes[];
 
   @OneToMany(() => Post_bookmarks, (post_bookmark) => post_bookmark.user, {cascade: true} )
   post_bookmarks!: Post_bookmarks[];

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -54,13 +54,21 @@ const deletePost = async (postId: number) => {
 const updatePostLikeByUser = async(userId: number, postId: number) => {
   const [isLiked] = await postDao.getPostLikesByUserPostId(userId, postId);
   
-  if(isLiked.Exist === "0") { 
-    await postDao.insertPostLikes(userId, postId)
-    return await postDao.getPostLike(userId, postId) }
+  switch (isLiked.Exist) {
+    case "0" :
+      await postDao.insertPostLikes(userId, postId)
+      const [case0] = await postDao.getPostLike(userId, postId)
+      case0.is_liked = +case0.is_liked;
+      return case0;
+    
+    case "1" :
+      await postDao.updatePostLikeByUser(userId, postId)
+      const [case1] = await postDao.getPostLike(userId, postId)
+      case1.is_liked = +case1.is_liked;
 
-  else if(isLiked.Exist === "1") { 
-    await postDao.updatePostLikeByUser(userId, postId)
-    return await postDao.getPostLike(userId, postId) }
+      if(case1.count_likes === null) { case1.count_likes = "0" }
+      return case1;
+  }
 }
 
 


### PR DESCRIPTION
entities 오류 수정 및 onDelete 옵션 수정, 게시글 좋아요 코드 수정
  - user_entity의 post_likes relation 오류 수정
  - post_entity, user_entity, post_likes_entity에 onDelete 옵션 추가
  - 게시글 좋아요 조건문을 if에서 switch로 변경
  - 좋아요 update 반환 값에서 is_liked 값을 string에서 number로 바꾸는 코드 추가
  - 같이 반환되는 count_likes 값이 null일 때 "0"으로 바꾸는 코드 추가

Issue: #25