### PR TITLE
Feature: 게시글 페이지 스크롤, 조회시 작성자 표시(is_owner)

### DIFF
--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -15,8 +15,9 @@ const createPost = asyncWrap (async (req: Request, res: Response) => {
 
 const getAllPosts = asyncWrap (async (req: Request, res: Response) => {
   const userId: number | null = req.body.foundUser;
+  const { offset, limit } = req.query;
 
-  const posts = await postService.getAllPosts(userId);
+  const posts = await postService.getAllPosts(userId, offset, limit);
   res.status(200).json(posts)
 })
 

--- a/src/dto/postDto.ts
+++ b/src/dto/postDto.ts
@@ -11,3 +11,19 @@ export class UpdatePostDTO {
   content?: string;
   images?: string;
 }
+
+export interface returnPostDTO {
+  id: number,
+  nickname: string,
+  user_id: number,
+  category: string,
+  category_id: number,
+  content: string,
+  created_at: Date,
+  count_comments: number | string | null,
+  comments: object[],
+  count_likes: number | string | null,
+  is_liked?: number | string | null,
+  is_marked?: number | string | null,
+  is_owner?: boolean
+}

--- a/src/models/postDao.ts
+++ b/src/models/postDao.ts
@@ -1,5 +1,5 @@
 import { myDataSource } from "../configs/typeorm_config";
-import { CreatePostDTO, UpdatePostDTO } from "../dto/postDto";
+import { CreatePostDTO, UpdatePostDTO, returnPostDTO } from "../dto/postDto";
 import { Posts } from "../entities/post_entity";
 import { Post_images } from "../entities/post_images_entity";
 import { Post_likes } from "../entities/post_likes_entity";
@@ -16,51 +16,46 @@ const createPost = async (categoryId: number | undefined, postData: CreatePostDT
 }
 
 
-const getAllPosts = async (userId: number | null): Promise<object[]> => {
-  // 해당 게시글 작성자인지 여부도 같이 표현해줄 것
-  // 무한스크롤, 12개씩
-
-  let query = ""
-  let select = ""
-  let owner = ""
-  let bookmark = ""
+const getAllPosts = async (userId: number | null, offset: any, limit: any): Promise<returnPostDTO[]> => {
+  let likeAndBookmark = ""
+  let leftJoinWithLikes = ""
+  let leftJoinWithBookmarks = ""
 
   if(userId != null) {
-  select = `, likes.is_liked as is_liked, bookmarks.is_marked as is_marked`
-  query = `LEFT JOIN (SELECT post_id, is_liked FROM post_likes WHERE user_id = ${userId}) likes ON p.id = likes.post_id`
-  owner = ``
-  bookmark = `LEFT JOIN (SELECT post_id, is_marked FROM post_bookmarks WHERE user_id = ${userId}) bookmarks ON p.id = bookmarks.post_id`
+    likeAndBookmark = `, likes.is_liked as is_liked, bookmarks.is_marked as is_marked`
+    leftJoinWithLikes = `LEFT JOIN (SELECT post_id, is_liked FROM post_likes WHERE user_id = ${userId}) likes ON p.id = likes.post_id`
+    leftJoinWithBookmarks = `LEFT JOIN (SELECT post_id, is_marked FROM post_bookmarks WHERE user_id = ${userId}) bookmarks ON p.id = bookmarks.post_id`
   }
 
   return await myDataSource.query(`
     SELECT 
       p.id, u.nickname, p.user_id, cate.name as category, p.category_id,
       p.content, p.created_at, c.count_comments, pl.count_likes
-      ${select}
+      ${likeAndBookmark}
     FROM posts p
     JOIN users u ON p.user_id = u.id
     JOIN categories cate ON p.category_id = cate.id
-    ${query}
-    ${bookmark}
+    ${leftJoinWithLikes}
+    ${leftJoinWithBookmarks}
     LEFT JOIN (SELECT post_id, COUNT(id) as count_comments FROM comments GROUP BY post_id) c ON p.id = c.post_id
     LEFT JOIN (SELECT post_id, COUNT(id) as count_likes FROM post_likes WHERE is_liked = 1 GROUP BY post_id) pl ON p.id = pl.post_id 
-    ORDER BY p.created_at DESC`)
+    ORDER BY p.created_at DESC
+    LIMIT ?, ?`, [+offset, +limit])
 }
 
 
-const getPostById = async (userId: number | null, postId: number): Promise<object> => {
-  // comments 가져오기도 같이. 해당 게시글 및 댓글 작성자인지 여부도 같이 표현해줄 것.
+const getPostById = async (userId: number | null, postId: number): Promise<returnPostDTO[]> => {
+  let likeAndBookmark = ""
 
-  let query = ""
   if(userId !== null) {
-  query = `, (SELECT is_liked FROM post_likes WHERE user_id = ${userId} AND post_id = ${postId}) as is_liked, 
+    likeAndBookmark = `, (SELECT is_liked FROM post_likes WHERE user_id = ${userId} AND post_id = ${postId}) as is_liked, 
   (SELECT is_marked FROM post_bookmarks WHERE user_id = ${userId} AND post_id = ${postId}) as is_marked`
   }
 
   return await myDataSource.query(`
     SELECT 
       p.id, u.nickname, p.user_id, cate.name as category, p.category_id,
-      p.content, p.created_at, pl.count_likes ${query}, c.count_comments, c.comments
+      p.content, p.created_at, pl.count_likes ${likeAndBookmark}, c.count_comments, c.comments
     FROM posts p
     JOIN users u ON p.user_id = u.id
     JOIN categories cate ON p.category_id = cate.id

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -25,13 +25,28 @@ const createPost = async (postData: CreatePostDTO) => {
 }
 
 
-const getAllPosts = async (userId: number | null) => {
-  return await postDao.getAllPosts(userId);
+const getAllPosts = async (userId: number | null, offset: any, limit: any) => {
+  const posts = await postDao.getAllPosts(userId, offset, limit);
+
+  if(userId !== null) {
+    posts.map((post) => {
+      if(post.user_id === userId) { post.is_owner = true }
+      else if(post.user_id !== userId) { post.is_owner = false }
+    })
+  }
+
+  return posts;
 }
 
 
 const getPostById = async (userId: number | null, postId: number) => {
-  return await postDao.getPostById(userId, postId);
+  const post = await postDao.getPostById(userId, postId);
+
+  if(userId !== null) {
+    if(post[0].user_id === userId) { post[0].is_owner = true }
+    else if (post[0].user_id !== userId) { post[0].is_owner = false }
+  }
+  return post;
 }
 
 


### PR DESCRIPTION
게시글 페이지 스크롤, 조회시 작성자 표시(is_owner)
  - 무한 스크롤 구현을 위해 offset과 limit을 query string으로 전달받아 한정된 갯수만큼 조회
  - 로그인 했을 때(userId !== null 인 경우), 메인 / 상세 게시글 반환 값에 해당 글 작성자인지 여부를 false | true로 표현
  - service단에서 is_owner를 추가하기 위해 게시글 반환 값의 타입을 returnPostDTO라는 interface로 정의

Rename: 게시글 조회에 사용한 변수명 변경
  - 목적이 보이도록 변경

Issue: #27