### PR TITLE
Feature: 댓글 C, D 및 댓글 좋아요 기능 구현

### DIFF
--- a/src/configs/typeorm_config.ts
+++ b/src/configs/typeorm_config.ts
@@ -1,6 +1,7 @@
 import { DataSource } from "typeorm"
 import { Categories } from "../entities/category_entity";
 import { Comments } from "../entities/comments_entity";
+import { Comment_likes } from "../entities/comment_likes_entity";
 import { Post_bookmarks } from "../entities/post_bookmarks_entity";
 import { Posts } from "../entities/post_entity";
 import { Post_images } from "../entities/post_images_entity";
@@ -14,7 +15,7 @@ const myDataSource = new DataSource ({
   username: process.env.TYPEORM_USERNAME,
   password: process.env.TYPEORM_PASSWORD,
   database: process.env.TYPEORM_DATABASE,
-  entities: [Categories ,Users, Posts, Post_likes, Post_images, Comments, Post_bookmarks],
+  entities: [Categories ,Users, Posts, Post_likes, Post_images, Comments, Post_bookmarks, Comment_likes],
   synchronize: true,
   logging: true
 });

--- a/src/controllers/commentController.ts
+++ b/src/controllers/commentController.ts
@@ -1,0 +1,41 @@
+import { Request, Response } from "express"
+import { asyncWrap } from "../common/asyncWrap";
+import { CreateCommentDTO } from "../dto/postDto";
+import commentService from "../services/commentService"
+
+
+
+
+const createComment = asyncWrap (async (req: Request, res: Response) => {
+  const postId = +req.params.post_id;
+  const commentData: CreateCommentDTO = req.body;
+
+  await commentService.createComment(postId, commentData)
+  res.status(201).json({ message: "Comment_Created" })
+})
+
+
+const deleteComment = asyncWrap (async (req: Request, res: Response) => {
+  const userId= req.body.foundUser;
+  const commentId = +req.params.comment_id;
+
+  await commentService.deleteComment(userId, commentId)
+  res.status(204).json({ message: "Comment_Deleted" })
+})
+
+
+const updateCommentLike = asyncWrap (async (req: Request, res: Response) => {
+  const userId= req.body.foundUser;
+  const commentId = +req.params.comment_id;
+
+  const state = await commentService.updateCommentLike(userId, commentId)
+  res.status(200).json(state)
+})
+
+
+
+export default { 
+  createComment,
+  deleteComment,
+  updateCommentLike
+}

--- a/src/dto/postDto.ts
+++ b/src/dto/postDto.ts
@@ -28,6 +28,11 @@ export interface returnPostDTO {
   is_owner?: boolean
 }
 
+export class CreateCommentDTO {
+  foundUser!: number;
+  comment!: string;
+}
+
 export interface commentsDTO {
   id: number,
   comment: string,

--- a/src/entities/comment_likes_entity.ts
+++ b/src/entities/comment_likes_entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm"
+import { Comments } from "./comments_entity";
+import { Users } from "./user_entity";
+
+@Entity('comment_likes')
+export class Comment_likes {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column("int")
+  user_id!: number;
+
+  @Column("int")
+  comment_id!: number;
+
+  @Column("tinyint")
+  is_liked!: number;
+
+  @ManyToOne(() => Users, (user) => user.comment_likes, {onDelete: 'CASCADE'} )
+  @JoinColumn({ name: "user_id", referencedColumnName: 'id' })
+  user!: Users;
+
+  @ManyToOne(() => Comments, (comment) => comment.comment_likes, {onDelete: 'CASCADE'} )
+  @JoinColumn({ name: "comment_id", referencedColumnName: 'id' })
+  comment!: Comments;
+}

--- a/src/entities/comments_entity.ts
+++ b/src/entities/comments_entity.ts
@@ -1,4 +1,5 @@
-import { BaseEntity, Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm"
+import { Column, CreateDateColumn, Entity, JoinColumn, OneToMany, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm"
+import { Comment_likes } from "./comment_likes_entity";
 import { Posts } from "./post_entity";
 import { Users } from "./user_entity";
 
@@ -28,6 +29,9 @@ export class Comments {
     onUpdate: 'CURRENT_TIMESTAMP(6)',
   })
   updated_at!: Date;
+
+  @OneToMany(() => Comment_likes, (comment_like) => comment_like.comment, {cascade: true})
+  comment_likes!: Comment_likes[];
 
   @ManyToOne(() => Users, (user) => user.comments )
   @JoinColumn({ name: "user_id", referencedColumnName: 'id' })

--- a/src/entities/user_entity.ts
+++ b/src/entities/user_entity.ts
@@ -1,5 +1,6 @@
 import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from "typeorm"
 import { Comments } from "./comments_entity";
+import { Comment_likes } from "./comment_likes_entity";
 import { Post_bookmarks } from "./post_bookmarks_entity";
 import { Posts } from "./post_entity";
 import { Post_likes } from "./post_likes_entity";
@@ -39,6 +40,9 @@ export class Users {
 
   @OneToMany(() => Comments, (comment) => comment.user)
   comments!: Comments[];
+
+  @OneToMany(() => Comment_likes, (comment_like) => comment_like.user, {cascade: true})
+  comment_likes!: Comment_likes[];
 
   @OneToMany(() => Post_likes, (post_like) => post_like.user, {cascade: true})
   post_likes!: Post_likes[];

--- a/src/models/commentDao.ts
+++ b/src/models/commentDao.ts
@@ -1,0 +1,81 @@
+import { myDataSource } from "../configs/typeorm_config";
+import { CreateCommentDTO } from "../dto/postDto";
+import { Comments } from "../entities/comments_entity";
+import { Comment_likes } from "../entities/comment_likes_entity";
+
+
+
+
+const createComment = async(postId: number, commentData: CreateCommentDTO): Promise<void> => {
+  await myDataSource.createQueryBuilder()
+  .insert()
+  .into(Comments)
+  .values({
+    post_id: postId,
+    user_id: commentData.foundUser,
+    comment: commentData.comment
+  })
+  .execute()
+}
+
+
+const deleteComment = async(userId: number, commentId: number) => {
+  return await myDataSource.createQueryBuilder()
+  .delete()
+  .from(Comments)
+  .where("id = :commentId AND user_id = :userId", { commentId, userId })
+  .execute()
+}
+
+
+const isCommentLikeExistedInEntity = async(userId: number, commentId: number) => {
+  return await myDataSource.query(`SELECT EXISTS (SELECT id FROM comment_likes WHERE user_id = ? AND comment_id = ?) as Exist`, [userId, commentId])
+}
+
+
+const insertCommentLike = async(userId: number, commentId: number) => {
+  return await myDataSource.createQueryBuilder()
+  .insert()
+  .into(Comment_likes)
+  .values({
+    user_id: userId,
+    comment_id: commentId,
+    is_liked: 1
+  })
+  .execute()
+}
+
+
+const updateCommentLikeByUser = async(userId: number, commentId: number) => {
+  await myDataSource.query(`
+  UPDATE comment_likes
+  SET is_liked =
+    CASE
+      WHEN is_liked = 0 THEN 1
+      WHEN is_liked = 1 THEN 0
+    END
+  WHERE user_id = ? AND comment_id = ?
+`, [userId, commentId])
+}
+
+
+const getCommentLike = async(userId: number, commentId: number) => {
+  return await myDataSource.query(`
+  SELECT 
+    is_liked,
+    (SELECT COUNT(id) FROM comment_likes WHERE comment_id = ? AND is_liked = 1 GROUP BY comment_id) as count_likes
+  FROM comment_likes WHERE user_id = ? AND comment_id = ?  
+`, [commentId, userId, commentId])
+}
+
+
+
+
+export default { 
+  createComment,
+  deleteComment,
+  isCommentLikeExistedInEntity,
+  insertCommentLike,
+  getCommentLike,
+  updateCommentLikeByUser
+}

--- a/src/routes/commentsRoute.ts
+++ b/src/routes/commentsRoute.ts
@@ -1,0 +1,11 @@
+import express from "express"
+import { validateToken } from "../middlewares/authorization"
+import commentController from "../controllers/commentController"
+
+const router = express.Router()
+
+router.post("/:post_id", validateToken, commentController.createComment)
+router.delete("/:comment_id", validateToken, commentController.deleteComment)
+router.patch("/:comment_id/like", validateToken, commentController.updateCommentLike)
+
+export default router

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,10 +1,12 @@
 import express from "express"
 import userRouter from "./usersRoute"
 import postRouter from "./postsRoute"
+import commentRouter from "./commentsRoute"
 
 const router = express.Router()
 
 router.use('/users', userRouter)
 router.use('/posts', postRouter)
+router.use('/comments', commentRouter)
 
 export default router

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -1,0 +1,43 @@
+import { CreateCommentDTO } from "../dto/postDto";
+import commentDao from "../models/commentDao";
+
+
+
+
+const createComment = async(postId: number, commentData: CreateCommentDTO) => {
+  await commentDao.createComment(postId, commentData);
+}
+
+
+const deleteComment = async(userId: number, commentId: number) => {
+  return await commentDao.deleteComment(userId, commentId);
+}
+
+
+const updateCommentLike = async(userId: number, commentId: number) => {
+  const [isLiked] = await commentDao.isCommentLikeExistedInEntity(userId, commentId);
+  
+  switch (isLiked.Exist) {
+    case "0" :
+      await commentDao.insertCommentLike(userId, commentId)
+      const [case0] = await commentDao.getCommentLike(userId, commentId)
+      case0.count_likes = +case0.count_likes;
+      return case0;
+    
+    case "1" :
+      await commentDao.updateCommentLikeByUser(userId, commentId)
+      const [case1] = await commentDao.getCommentLike(userId, commentId)
+      case1.count_likes = +case1.count_likes;
+      if(case1.count_likes === null) { case1.count_likes = 0 }
+      return case1;
+  }
+}
+
+
+
+
+export default {
+  createComment,
+  deleteComment,
+  updateCommentLike
+}


### PR DESCRIPTION
댓글 C, D 및 댓글 좋아요 기능 구현
  - 댓글 API를 위한 commentRoute 생성 및 comment 파일 분리

  - 댓글 작성 및 삭제 구현
    - postId와 commentData를 이용해 댓글 insert
    - postId는 params로 전달 
    - commentData 타입으로 인증을 거쳐 foundUser가 담긴 CreateCommentDTO 추가 
    - 로그인한 유저의 userId, params의 commentId를 이용해 댓글 삭제

  - 댓글 좋아요 구현 
    - comments, users 엔티티의 중간 테이블 comment_likes 엔티티 생성, config에 추가
      - onDelete 옵션
      - 로그인한 유저가 댓글 좋아요 누를 때, userId, commentId로 comment_likes 엔티티에서 Exist 조회
      - Exist = 0인 경우(한번도 좋아요 누른 적 없음), 해당 데이터가 comment_likes에 저장
      - Exist = 1인 경우(기존에 좋아요를 눌렀던 적 있음), CASE WHEN 조건문에 따라 0에서 1, 1에서 0으로 is_liked 값이 수정
      - 수정된 값에 따라 좋아요 수 COUNT 값도 변동
      - is_liked를 tinyint로 지정함으로써, service단에서 반환 값의 number 타입 변환 코드 축소(post_like와 비교)

Issue: #31