### PR TITLE
Refactor: 게시글 좋아요 및 북마크 코드 리팩토링

### DIFF
--- a/src/dto/postDto.ts
+++ b/src/dto/postDto.ts
@@ -44,9 +44,9 @@ export interface commentsDTO {
 
 export interface returnPostLikeDTO {
   count_likes: number | string,
-  is_liked: number | string
+  is_liked: number
 }
 
 export interface returnBookmarkDTO {
-  is_marked: number | string
+  is_marked: number
 }

--- a/src/entities/post_bookmarks_entity.ts
+++ b/src/entities/post_bookmarks_entity.ts
@@ -13,8 +13,8 @@ export class Post_bookmarks {
   @Column("int")
   post_id!: number;
 
-  @Column("char", { length: 1 })
-  is_marked!: string;
+  @Column("tinyint")
+  is_marked!: number;
 
   @ManyToOne(() => Users, (user) => user.post_bookmarks, {onDelete: 'CASCADE'} )
   @JoinColumn({ name: "user_id", referencedColumnName: 'id' })

--- a/src/entities/post_likes_entity.ts
+++ b/src/entities/post_likes_entity.ts
@@ -13,8 +13,8 @@ export class Post_likes {
   @Column("int")
   post_id!: number;
 
-  @Column("char", { length: 1 })
-  is_liked!: string;
+  @Column("tinyint")
+  is_liked!: number;
 
   @ManyToOne(() => Users, (user) => user.post_likes, {onDelete: 'CASCADE'} )
   @JoinColumn({ name: "user_id", referencedColumnName: 'id' })

--- a/src/models/likeAndBookmarkDao.ts
+++ b/src/models/likeAndBookmarkDao.ts
@@ -20,7 +20,7 @@ const insertPostLike = async(userId: number, postId: number): Promise<InsertResu
   .values({
     user_id: userId,
     post_id: postId,
-    is_liked: "1"
+    is_liked: 1
   })
   .execute()
 }
@@ -64,7 +64,7 @@ const insertPostBookmarks = async(userId: number, postId: number): Promise<void>
   .values({
     user_id: userId,
     post_id: postId,
-    is_marked: "1"
+    is_marked: 1
   })
   .execute()
 }
@@ -83,12 +83,13 @@ const updatePostBookmark = async(userId: number, postId: number): Promise<void> 
 }
 
 
-const getPostBookmark = async(userId: number, postId: number): Promise<returnBookmarkDTO[]> => {
-  return await myDataSource.query(`
-    SELECT 
-      is_marked
-    FROM post_bookmarks WHERE user_id = ? AND post_id = ?  
-  `, [userId, postId])
+const getPostBookmark = async(userId: number, postId: number): Promise<returnBookmarkDTO | undefined> => {
+  return await myDataSource.createQueryBuilder()
+    .select("is_marked")
+    .from(Post_bookmarks, "bookmark")
+    .where("user_id = :userId", { userId })
+    .andWhere("post_id = :postId", { postId })
+    .getRawOne()
 }
 
 

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -91,14 +91,12 @@ const updatePostLikeByUser = async(userId: number, postId: number) => {
     case "0" :
       await likeAndBookmarkDao.insertPostLike(userId, postId)
       const [case0] = await likeAndBookmarkDao.getPostLike(userId, postId)
-      case0.is_liked = +case0.is_liked;
       case0.count_likes = +case0.count_likes;
       return case0;
     
     case "1" :
       await likeAndBookmarkDao.updatePostLikeByUser(userId, postId)
       const [case1] = await likeAndBookmarkDao.getPostLike(userId, postId)
-      case1.is_liked = +case1.is_liked;
       case1.count_likes = +case1.count_likes;
       if(case1.count_likes === null) { case1.count_likes = 0 }
       return case1;
@@ -112,15 +110,11 @@ const updatePostBookmark = async(userId: number, postId: number) => {
   switch(isMarked.Exist) { 
     case "0" :
       await likeAndBookmarkDao.insertPostBookmarks(userId, postId)
-      const [case0] = await likeAndBookmarkDao.getPostBookmark(userId, postId)
-      case0.is_marked = +case0.is_marked;
-      return case0;
+      return await likeAndBookmarkDao.getPostBookmark(userId, postId)
 
     case "1" : 
       await likeAndBookmarkDao.updatePostBookmark(userId, postId)
-      const [case1] = await likeAndBookmarkDao.getPostBookmark(userId, postId)
-      case1.is_marked = +case1.is_marked;
-      return case1;
+      return await likeAndBookmarkDao.getPostBookmark(userId, postId)
     }
 } 
 


### PR DESCRIPTION
게시글 좋아요 및 북마크 코드 리팩토링
  - post_likes, post_bookmarks 엔티티의 is_liked, is_marked column 타입 변경(tinyint) 
    - column 타입 변경에 따라 좋아요, 북마크 insert문 값을 string 타입 1에서 number 타입 1로 변경 
    - returnPostLikeDTO, returnBookmarkDTO의 타입을 number만 작성 
    - service단에 있던 반환 값을 number타입으로 변환하는 코드 삭제

  - 북마크 결과 값을 반환하는 getPostBookmark를 RawQuery에서 ORM으로 변경

Issue: #33