### PR TITLE
Feature: 마이 페이지 기능 추가(부분 수정 필요)

### DIFF
--- a/src/common/keyErrorCheck.ts
+++ b/src/common/keyErrorCheck.ts
@@ -1,7 +1,7 @@
-import { UserDTO } from "../dto/userDto"
+import { CreateUserDTO } from "../dto/userDto"
 import { RegExpError } from "./createError"
 
-export const keyError = (userData: UserDTO) => {
+export const keyError = (userData: CreateUserDTO) => {
   const accountRegex = /^[\da-zA-Z]{6,15}$/g
   const passwordRegex = /^(?=.*\d)(?=.*[a-zA-Z])(?=.*[@#*!^])[\da-zA-Z@#*!^]{8,16}$/g
   const nicknameRegex = /^[a-zA-z0-9.\-_!?^()/@#*!^ㄱ-ㅎ|ㅏ-ㅣ|가-힣]{1,8}$/g

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express"
 import { asyncWrap } from "../common/asyncWrap"
 import { keyError } from "../common/keyErrorCheck";
-import { UserDTO } from "../dto/userDto"
+import { CreateUserDTO, UpdateUserDTO } from "../dto/userDto"
 import userService from "../services/userService"
 import { BadRequestExceptions } from "../common/createError"
 
@@ -16,7 +16,7 @@ const userAvailableCheck = asyncWrap (async (req: Request, res: Response) => {
 
 
 const createUser = asyncWrap (async (req: Request, res: Response) => {
-  const userData: UserDTO = req.body;
+  const userData: CreateUserDTO = req.body;
   keyError(userData);
 
   await userService.createUser(userData);
@@ -25,7 +25,7 @@ const createUser = asyncWrap (async (req: Request, res: Response) => {
 
 
 const signInUser = asyncWrap (async (req: Request, res: Response) => {
-  const userData: UserDTO = req.body;
+  const userData: CreateUserDTO = req.body;
 
   const result = await userService.signInUser(userData);
   res.status(200).json({ message: "Login_Success", result });
@@ -48,11 +48,58 @@ const kakaoLogout = asyncWrap (async (req: Request, res: Response) => {
 })
 
 
+const getMyPage = asyncWrap (async (req: Request, res: Response) => {
+  const userId: number = req.body.foundUser;
+  
+  const myPage = await userService.getMyPage(userId)
+  res.status(200).json(myPage)
+})
+
+
+const updateUserName = asyncWrap (async (req: Request, res: Response) => {
+  const updateData: UpdateUserDTO = req.body;
+
+  await userService.updateUserName(updateData)
+  res.status(200).json({ message: "Nickname_Updated" })
+})
+
+
+const getMyPosts = asyncWrap (async (req: Request, res: Response) => {
+  const userId: number = req.body.foundUser;
+
+  const posts = await userService.getMyPosts(userId)
+  res.status(200).json(posts)
+})
+
+
+const getMyBookmarks = asyncWrap (async (req: Request, res: Response) => {
+  const userId: number = req.body.foundUser;
+
+  const bookmarks = await userService.getMyBookmarks(userId)
+  res.status(200).json(bookmarks)
+})
+
+
+// 비식별화된 유저에 대해 로그인 등의 접근을 어떻게 막을건가 > 별도 테이블에 구성? 아니면 로그인 시 체크, 유령회원일 경우 사용불가 account로 alert?
+// 일정 시간 지나면 자동으로 삭제? 그렇다면 onDelele 옵션을 조건따라 적용해야... 직접 deletePost API로 요청들어온 경우에만 onDelete 되도록...
+const updateWithdrowUser = asyncWrap (async (req: Request, res: Response) => {
+  const userId: number = req.body.foundUser;
+
+  await userService.updateWithdrowUser(userId)
+  res.status(200).json({ messge: "Withdrow_Success" })
+})
+
+
 
 export default { 
   userAvailableCheck,
   createUser,
   signInUser,
   kakaoLogin,
-  kakaoLogout
+  kakaoLogout,
+  getMyPage,
+  getMyPosts,
+  getMyBookmarks,
+  updateUserName,
+  updateWithdrowUser
 }

--- a/src/dto/userDto.ts
+++ b/src/dto/userDto.ts
@@ -1,6 +1,12 @@
-export class UserDTO {
+export class CreateUserDTO {
   account!: string;
   password!: string;
   email!: string; 
+  nickname!: string;
+}
+
+
+export class UpdateUserDTO {
+  foundUser!: string;
   nickname!: string;
 }

--- a/src/models/userDao.ts
+++ b/src/models/userDao.ts
@@ -1,6 +1,10 @@
 import { DuplicateError } from "../common/createError"
 import { myDataSource } from "../configs/typeorm_config"
-import { UserDTO } from "../dto/userDto"
+import { CreateUserDTO, UpdateUserDTO } from "../dto/userDto"
+import { Categories } from "../entities/category_entity"
+import { Post_bookmarks } from "../entities/post_bookmarks_entity"
+import { Posts } from "../entities/post_entity"
+import { Post_images } from "../entities/post_images_entity"
 import { Users } from "../entities/user_entity"
 
 
@@ -19,7 +23,7 @@ const getUserExistsById = async (userId: number): Promise<object[]> => {
 }
 
 
-const createUser = async (userData: UserDTO): Promise<object> => {
+const createUser = async (userData: CreateUserDTO): Promise<object> => {
   return await myDataSource
     .createQueryBuilder()
     .insert()
@@ -34,7 +38,7 @@ const createUser = async (userData: UserDTO): Promise<object> => {
 }
 
 
-const getUserByAccount = async (userData: UserDTO): Promise<any> => {
+const getUserByAccount = async (userData: CreateUserDTO): Promise<any> => {
   const account = userData.account;
 
   return await myDataSource.query(`
@@ -60,12 +64,85 @@ const createSNSUser = async (account: string, email: string, nickname: string): 
 }
 
 
-const getSNSUser = async (account: string, email: string) => {// 인자로 email 올 수 있는 거 맞아?
+const getSNSUser = async (account: string, email: string) => {
   return await myDataSource.query(`
   SELECT 
     id, email, nickname 
   FROM users 
-  WHERE email = ? AND account = ?`, [email, account]) // DB명 변경 주의
+  WHERE email = ? AND account = ?`, [email, account])
+}
+
+
+const getMyPage = async (userId: number) => {
+  return await myDataSource.createQueryBuilder()
+    .select(["id", "account", "nickname"])
+    .from(Users, "users")
+    .where("id = :userId", { userId })
+    .getRawOne()
+}
+
+
+const updateUserName = async (updateData: UpdateUserDTO) => {
+  return await myDataSource.createQueryBuilder()
+    .update(Users)
+    .set({
+      nickname: updateData.nickname
+    })
+    .where("id = :userId", { userId: updateData.foundUser })
+    .execute()
+}
+
+
+const getMyPosts = async (userId: number) => {
+  return await myDataSource.getRepository(Posts)
+    .createQueryBuilder("posts")
+    .select(["posts.id AS id", "posts.content AS content", "posts.created_at AS created_at",
+        "post_images.post_id AS images",
+        "category.id AS category_id", "category.name AS category"])
+    .addSelect("COUNT(comments.id) AS count_comments")
+    .addSelect("COUNT(post_likes.id) AS count_likes")
+    .innerJoin("posts.category", "category")
+    .leftJoin("posts.comments", "comments")
+    .leftJoin("posts.post_likes", "post_likes")
+    .leftJoin("posts.post_images", "post_images")
+    .where("posts.user_id = :userId", { userId })
+    .groupBy("posts.id")
+    .orderBy("posts.created_at", "DESC")
+    .getRawMany()
+}
+
+
+const getMyBookmarks = async (userId: number) => {
+  return await myDataSource.query(`
+  SELECT DISTINCT 
+    bookmarks.id, bookmarks.post_id, p.content, p.category_id as category_id, p.category as category, 
+    p.count_likes, p.count_comments, p.images
+  FROM post_bookmarks bookmarks
+  JOIN
+    (	SELECT 
+        posts.id, posts.content, categories.id as category_id, categories.name as category,
+        post_images.post_id as images, COUNT(post_likes.id) as count_likes, COUNT(comments.id) as count_comments
+      FROM posts
+      JOIN categories ON posts.category_id = categories.id
+      LEFT JOIN post_images ON posts.id = post_images.post_id
+      LEFT JOIN post_likes ON posts.id = post_likes.post_id
+      LEFT JOIN comments ON posts.id = comments.post_id
+      GROUP BY posts.id
+    ) p ON bookmarks.post_id = p.id
+  WHERE is_marked = 1 AND bookmarks.user_id = ?`, [userId])
+}
+
+
+const updateWithdrowUser = async (userId: number) => {
+  return await myDataSource.createQueryBuilder()
+    .update(Users)
+    .set({
+      account: "",
+      email: "",
+      nickname: "유령회원"
+    })
+    .where("id = :userId", { userId })
+    .execute()
 }
 
 
@@ -77,5 +154,10 @@ export default {
   createUser,
   getUserByAccount,
   createSNSUser,
-  getSNSUser
+  getSNSUser,
+  getMyPage,
+  getMyPosts,
+  getMyBookmarks,
+  updateUserName,
+  updateWithdrowUser
 }

--- a/src/routes/usersRoute.ts
+++ b/src/routes/usersRoute.ts
@@ -1,5 +1,6 @@
 import express from "express"
 import userController from "../controllers/userController"
+import { validateToken } from "../middlewares/authorization"
 
 const router = express.Router()
 
@@ -8,6 +9,11 @@ router.post('/signup', userController.createUser)
 router.post('/signin', userController.signInUser)
 router.post('/kakaoLogin', userController.kakaoLogin)
 router.post('/kakaoLogout', userController.kakaoLogout)
+router.get('/my', validateToken, userController.getMyPage)
+router.patch('/my/name', validateToken, userController.updateUserName)
+router.patch('/my', validateToken, userController.updateWithdrowUser) // 임시
+router.get('/my/posts', validateToken, userController.getMyPosts)
+router.get('/my/bookmarks', validateToken, userController.getMyBookmarks)
 
 
 export default router


### PR DESCRIPTION
마이 페이지 기능 추가(부분 수정 필요)
  - 로그인 후 이용 가능하도록 인증인가 미들웨어 사용
  - 유저 닉네임 수정, 유저의 게시글 및 북마크 목록 조회, 회원 탈퇴 기능이 포함된 페이지
  - userId를 이용하여 유저의 게시글 및 북마크 조회
    - 글의 내용, 카테고리, 좋아요 수, 댓글 수, 이미지 포함 유무, is_liked 조회
    - 좋아요 및 댓글 수의 숫자 타입 변환을 위한 if문이 service단에 구현
  - 유저 닉네임 수정 기능
    - 변경할 닉네임을 updateData로 받아 수정
  - 회원 탈퇴 기능
    - 회원 탈퇴로 users의 데이터를 delete하지 않고 비식별화 방식으로 update
---
수정 필요
  - 게시글 및 북마크 조회 시 is_liked 구현
  - 북마크 조회 결과의 숫자 타입 변환 구현
  - 게시글, 북마크 조회 SQL문 더 고민
  - 비식별화 후, 탈퇴 회원에 대한 처리? 동일 계정 재가입 허용?