### PR TITLE
Update: 게시글 카테고리 기능 > 중복 선택으로 변경, 단일 이미지 > 여러 이미지 작성 변경

### DIFF
--- a/src/dto/postDto.ts
+++ b/src/dto/postDto.ts
@@ -1,23 +1,22 @@
 export class CreatePostDTO {
   foundUser!: number;
-  category!: string;
+  category!: string[];
   content!: string;
-  images?: string;
+  images?: string[];
 }
 
 export class UpdatePostDTO {
   foundUser!: number;
-  category?: string;
+  category?: string[];
   content?: string;
-  images?: string;
+  images?: string[];
 }
 
 export interface returnPostDTO {
   id: number,
   nickname: string,
   user_id: number,
-  category: string,
-  category_id: number,
+  category_id: string,
   content: string,
   created_at: Date,
   count_comments: number | string | null,

--- a/src/entities/category_entity.ts
+++ b/src/entities/category_entity.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, Column, CreateDateColumn, Entity, JoinColumn, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm"
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm"
 import { Posts } from "./post_entity";
 
 @Entity('categories')
@@ -18,6 +18,6 @@ export class Categories {
   })
   created_at!: Date;
 
-  @OneToMany(() => Posts, (post) => post.category )
-  posts!: Posts[];
+  // @OneToMany(() => Posts, (post) => post.category )
+  // posts!: Posts[];
 }

--- a/src/entities/post_entity.ts
+++ b/src/entities/post_entity.ts
@@ -17,8 +17,8 @@ export class Posts {
   @Column("int")
   user_id!: number;
 
-  @Column("int")
-  category_id!: number;
+  @Column("varchar")
+  category_id!: string;
 
   @CreateDateColumn({
     type: 'timestamp',
@@ -37,9 +37,9 @@ export class Posts {
   @JoinColumn({ name: "user_id", referencedColumnName: 'id' })
   user!: Users;
 
-  @ManyToOne(() => Categories, (category) => category.posts )
-  @JoinColumn({ name: "category_id", referencedColumnName: 'id' })
-  category!: Categories;
+  // @ManyToOne(() => Categories, (category) => category.posts )
+  // @JoinColumn({ name: "category_id", referencedColumnName: 'id' })
+  // category!: Categories;
 
   @OneToMany(() => Comments, (comment) => comment.post )
   comments!: Comments[];

--- a/src/models/userDao.ts
+++ b/src/models/userDao.ts
@@ -1,10 +1,7 @@
 import { DuplicateError } from "../common/createError"
 import { myDataSource } from "../configs/typeorm_config"
 import { CreateUserDTO, UpdateUserDTO } from "../dto/userDto"
-import { Categories } from "../entities/category_entity"
-import { Post_bookmarks } from "../entities/post_bookmarks_entity"
 import { Posts } from "../entities/post_entity"
-import { Post_images } from "../entities/post_images_entity"
 import { Users } from "../entities/user_entity"
 
 
@@ -98,10 +95,9 @@ const getMyPosts = async (userId: number) => {
     .createQueryBuilder("posts")
     .select(["posts.id AS id", "posts.content AS content", "posts.created_at AS created_at",
         "post_images.post_id AS images",
-        "category.id AS category_id", "category.name AS category"])
+        "posts.category_id AS category"])
     .addSelect("COUNT(comments.id) AS count_comments")
     .addSelect("COUNT(post_likes.id) AS count_likes")
-    .innerJoin("posts.category", "category")
     .leftJoin("posts.comments", "comments")
     .leftJoin("posts.post_likes", "post_likes")
     .leftJoin("posts.post_images", "post_images")
@@ -115,15 +111,14 @@ const getMyPosts = async (userId: number) => {
 const getMyBookmarks = async (userId: number) => {
   return await myDataSource.query(`
   SELECT DISTINCT 
-    bookmarks.id, bookmarks.post_id, p.content, p.category_id as category_id, p.category as category, 
+    bookmarks.id, bookmarks.post_id, p.content, p.category, 
     p.count_likes, p.count_comments, p.images
   FROM post_bookmarks bookmarks
   JOIN
     (	SELECT 
-        posts.id, posts.content, categories.id as category_id, categories.name as category,
+        posts.id, posts.content, posts.category_id as category,
         post_images.post_id as images, COUNT(post_likes.id) as count_likes, COUNT(comments.id) as count_comments
       FROM posts
-      JOIN categories ON posts.category_id = categories.id
       LEFT JOIN post_images ON posts.id = post_images.post_id
       LEFT JOIN post_likes ON posts.id = post_likes.post_id
       LEFT JOIN comments ON posts.id = comments.post_id

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -131,6 +131,7 @@ const updateUserName = async (updateData: UpdateUserDTO) => {
 const getMyPosts = async (userId: number) => {
   const posts = await userDao.getMyPosts(userId)
   posts.map((post) => {
+    post.category = JSON.parse(post.category)
     if(post.count_comments !== null) post.count_comments = +post.count_comments
     if(post.count_likes !== null) post.count_likes = +post.count_likes
     if(post.is_liked !== null && post.is_liked !== undefined) post.is_liked = +post.is_liked


### PR DESCRIPTION
게시글 카테고리 기능, 중복 선택으로 변경
  - 기존에 1개의 카테고리만 선택 가능한 부분을 중복 선택 가능하도록 변경
    - 전달받는 카테고리 배열을 위해 DTO에서 category를 string[]로 타입 변경 
    - 카테고리를 전달받아 해당 값을 JSON.stringify()를 사용해 DB에 저장 
    - 기존에 posts와 categories 엔티티의 참조관계 삭제, categories 엔티티 사용 안함 
    - 게시글 조회 SQL문에서 categories INNER JOIN 문 삭제 
    - 게시글 조회시 저장된 string 형태의 카테고리 값을 JSON.parse() 처리

단일 이미지 > 여러 이미지 작성 변경
  - 게시글 작성시 1개의 이미지만 작성 가능하던 부분을 이미지 배열을 받아 작성할 수 있도록 변경 
    - map을 통해 배열의 각 이미지 url들을 DB에 insert하는 createPostImages 함수를 반복 호출

  - 이미지 수정 관련 코드 필요(추후 예정)

Fix: 로그인 후 게시글 조회시 string의 count값을 number 타입으로 변경
  - 비로그인 시 number 타입으로 조회되던 값이 로그인하면 string이 되던 오류 수정

Issue: #36