### PR TITLE
Update: 유저(회원탈퇴, 북마크 목록) 및 엔티티들, 게시글 이미지 수정, offset 관련 코드 수정

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -82,10 +82,10 @@ const getMyBookmarks = asyncWrap (async (req: Request, res: Response) => {
 
 // 비식별화된 유저에 대해 로그인 등의 접근을 어떻게 막을건가 > 별도 테이블에 구성? 아니면 로그인 시 체크, 유령회원일 경우 사용불가 account로 alert?
 // 일정 시간 지나면 자동으로 삭제? 그렇다면 onDelele 옵션을 조건따라 적용해야... 직접 deletePost API로 요청들어온 경우에만 onDelete 되도록...
-const updateWithdrowUser = asyncWrap (async (req: Request, res: Response) => {
+const withdrowUser = asyncWrap (async (req: Request, res: Response) => {
   const userId: number = req.body.foundUser;
 
-  await userService.updateWithdrowUser(userId)
+  await userService.withdrowUser(userId)
   res.status(200).json({ messge: "Withdrow_Success" })
 })
 
@@ -101,5 +101,5 @@ export default {
   getMyPosts,
   getMyBookmarks,
   updateUserName,
-  updateWithdrowUser
+  withdrowUser
 }

--- a/src/entities/comments_entity.ts
+++ b/src/entities/comments_entity.ts
@@ -33,11 +33,11 @@ export class Comments {
   @OneToMany(() => Comment_likes, (comment_like) => comment_like.comment, {cascade: true})
   comment_likes!: Comment_likes[];
 
-  @ManyToOne(() => Users, (user) => user.comments )
+  @ManyToOne(() => Users, (user) => user.comments, {onDelete: 'CASCADE'} )
   @JoinColumn({ name: "user_id", referencedColumnName: 'id' })
   user!: Users;
 
-  @ManyToOne(() => Posts, (post) => post.comments )
+  @ManyToOne(() => Posts, (post) => post.comments, {onDelete: 'CASCADE'} )
   @JoinColumn({ name: "post_id", referencedColumnName: 'id' })
   post!: Posts;
 }

--- a/src/entities/post_entity.ts
+++ b/src/entities/post_entity.ts
@@ -33,7 +33,7 @@ export class Posts {
   })
   updated_at!: Date;
 
-  @ManyToOne(() => Users, (user) => user.posts )
+  @ManyToOne(() => Users, (user) => user.posts, {onDelete: 'CASCADE'} )
   @JoinColumn({ name: "user_id", referencedColumnName: 'id' })
   user!: Users;
 
@@ -41,7 +41,7 @@ export class Posts {
   // @JoinColumn({ name: "category_id", referencedColumnName: 'id' })
   // category!: Categories;
 
-  @OneToMany(() => Comments, (comment) => comment.post )
+  @OneToMany(() => Comments, (comment) => comment.post, {cascade: true} )
   comments!: Comments[];
 
   @OneToMany(() => Post_likes, (post_like) => post_like.post, {cascade: true} )

--- a/src/entities/user_entity.ts
+++ b/src/entities/user_entity.ts
@@ -35,10 +35,10 @@ export class Users {
   })
   updated_at!: Date;
 
-  @OneToMany(() => Posts, (post) => post.user)
+  @OneToMany(() => Posts, (post) => post.user, {cascade: true})
   posts!: Posts[];
 
-  @OneToMany(() => Comments, (comment) => comment.user)
+  @OneToMany(() => Comments, (comment) => comment.user, {cascade: true})
   comments!: Comments[];
 
   @OneToMany(() => Comment_likes, (comment_like) => comment_like.user, {cascade: true})

--- a/src/models/postDao.ts
+++ b/src/models/postDao.ts
@@ -59,7 +59,7 @@ const getAllPosts = async (userId: number | null, offset: any, limit: any): Prom
     LEFT JOIN (SELECT post_id, COUNT(id) as count_comments FROM comments GROUP BY post_id) c ON p.id = c.post_id
     LEFT JOIN (SELECT post_id, COUNT(id) as count_likes FROM post_likes WHERE is_liked = 1 GROUP BY post_id) pl ON p.id = pl.post_id 
     ORDER BY p.created_at DESC
-    LIMIT ?, ?`, [+offset, +limit])
+    LIMIT ?, 12`, [+offset * 12])
 }
 
 
@@ -130,14 +130,24 @@ const updatePost = async(postId: number, category: string | undefined, postData:
 }
 
 
+const deletePostImages = async(postId: number): Promise<void> => {
+  await myDataSource.createQueryBuilder()
+  .delete()
+  .from(Post_images)
+  .where("post_id = :postId", { postId })
+  .execute()
+}
+
+
 const updatePostImages = async(postId: number, postImage: string): Promise<void> => {
   await myDataSource.createQueryBuilder()
-    .update(Post_images)
-    .set({
-      image_url: postImage
-    })
-    .where("id = :postId", {postId})
-    .execute()
+  .insert()
+  .into(Post_images)
+  .values({
+    post_id: postId,
+    image_url: postImage
+  })
+  .execute()
 }
 
 
@@ -159,6 +169,7 @@ export default {
   getPostById,
   getCommentsByPost,
   updatePost,
+  deletePostImages,
   updatePostImages,
   deletePost
 }

--- a/src/models/searchDao.ts
+++ b/src/models/searchDao.ts
@@ -30,8 +30,8 @@ const getPostByKeyword = async(userId: number | null, keyword: searchDTO, offset
     LEFT JOIN (SELECT post_id, COUNT(id) as count_likes FROM post_likes WHERE is_liked = 1 GROUP BY post_id) pl ON p.id = pl.post_id 
     WHERE content REGEXP ?
     ORDER BY p.created_at DESC
-    LIMIT 12 * ?, 12
-  `, [keyword.q, +offset])
+    LIMIT ?, 12
+  `, [keyword.q, +offset * 12])
 }
 
 
@@ -41,8 +41,8 @@ const getUserByKeyword = async(keyword: searchDTO, offset: any) => {
       id, nickname, account
     FROM users
     WHERE nickname REGEXP ?
-    LIMIT 12 * ?, 12
-  `, [keyword.q, +offset])
+    LIMIT ?, 12
+  `, [keyword.q, +offset * 12])
 }
 
 
@@ -71,8 +71,8 @@ const getCategoryByKeyword = async(userId: number | null, keyword: searchDTO, of
     LEFT JOIN (SELECT post_id, COUNT(id) as count_likes FROM post_likes WHERE is_liked = 1 GROUP BY post_id) pl ON p.id = pl.post_id 
     WHERE category_id REGEXP ?
     ORDER BY p.created_at DESC
-    LIMIT 12 * ?, 12
-  `, [keyword.q, +offset])
+    LIMIT ?, 12
+  `, [keyword.q, +offset * 12])
 }
 
 
@@ -111,8 +111,8 @@ const getPostByCategory = async(userId: number | null, category: string[], offse
     LEFT JOIN (SELECT post_id, COUNT(id) as count_likes FROM post_likes WHERE is_liked = 1 GROUP BY post_id) pl ON p.id = pl.post_id 
     WHERE ${searchQuery}
     ORDER BY p.created_at DESC
-    LIMIT 12 * ?, 12
-  `,[+offset])  
+    LIMIT ?, 12
+  `,[+offset * 12])  
 }
 
 

--- a/src/models/userDao.ts
+++ b/src/models/userDao.ts
@@ -128,14 +128,10 @@ const getMyBookmarks = async (userId: number) => {
 }
 
 
-const updateWithdrowUser = async (userId: number) => {
+const withdrowUser = async (userId: number) => {
   return await myDataSource.createQueryBuilder()
-    .update(Users)
-    .set({
-      account: "",
-      email: "",
-      nickname: "유령회원"
-    })
+    .delete()
+    .from(Users)
     .where("id = :userId", { userId })
     .execute()
 }
@@ -154,5 +150,5 @@ export default {
   getMyPosts,
   getMyBookmarks,
   updateUserName,
-  updateWithdrowUser
+  withdrowUser
 }

--- a/src/routes/usersRoute.ts
+++ b/src/routes/usersRoute.ts
@@ -11,7 +11,7 @@ router.post('/kakaoLogin', userController.kakaoLogin)
 router.post('/kakaoLogout', userController.kakaoLogout)
 router.get('/my', validateToken, userController.getMyPage)
 router.patch('/my/name', validateToken, userController.updateUserName)
-router.patch('/my', validateToken, userController.updateWithdrowUser) // 임시
+router.patch('/my', validateToken, userController.withdrowUser) // 임시
 router.get('/my/posts', validateToken, userController.getMyPosts)
 router.get('/my/bookmarks', validateToken, userController.getMyBookmarks)
 

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -77,12 +77,11 @@ const getPostById = async (userId: number | null, postId: number) => {
 const updatePost = async (postId: number, postData: UpdatePostDTO) => {
 
   if(postData.images !== undefined) {
+    await postDao.deletePostImages(postId)
     postData.images.map( async (image) => {
       await postDao.updatePostImages(postId, image)
     })
   }
-
-// 수정된 이미지 업로드 추가
 
   return await postDao.updatePost(postId, JSON.stringify(postData.category), postData);
 }

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -68,7 +68,6 @@ const getCategoryByKeyword = async(userId: number | null, keyword: searchDTO, of
 const getPostByCategory = async(userId: number | null, keyword: searchDTO, offset: any) => {
   let categoryArr: string[] = [];
 
-  console.log(11111111, userId)
   JSON.stringify(keyword.category).split('"').map((el) => {
     const category = getCategoryById(el)
     if(category !== undefined) { 

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -143,12 +143,21 @@ const getMyPosts = async (userId: number) => {
 
 
 const getMyBookmarks = async (userId: number) => {
-  return await userDao.getMyBookmarks(userId)
+  const posts = await userDao.getMyBookmarks(userId)
+  posts.map((post: { category: string; count_comments: number | null; count_likes: number | null; is_liked: number | null | undefined; is_marked: number | null | undefined; }) => {
+    post.category = JSON.parse(post.category)
+    if(post.count_comments !== null) post.count_comments = +post.count_comments
+    if(post.count_likes !== null) post.count_likes = +post.count_likes
+    if(post.is_liked !== null && post.is_liked !== undefined) post.is_liked = +post.is_liked
+    if(post.is_marked !== null && post.is_marked !== undefined) post.is_marked = +post.is_marked
+  })
+
+  return posts;
 }
 
 
-const updateWithdrowUser = async (userId: number) => {
-  return await userDao.updateWithdrowUser(userId)
+const withdrowUser = async (userId: number) => {
+  return await userDao.withdrowUser(userId)
 }
 
 
@@ -162,5 +171,5 @@ export default {
   getMyPosts,
   getMyBookmarks,
   updateUserName,
-  updateWithdrowUser
+  withdrowUser
 }


### PR DESCRIPTION
유저(회원탈퇴, 북마크 목록) 및 엔티티들, 게시글 offset 관련 코드 수정
- 유저(회원탈퇴, 북마크 목록)
  - 유저 회원탈퇴 API의 함수 명칭을 변경하고 method를 update에서 delete로 변경
  - 유저의 북마크 목록 조회시 북마크, 좋아요 여부와 조회된 게시글의 좋아요, 댓글 수를 숫자로 타입 변경하는 코드 추가

- 게시글, 유저, 댓글 엔티티의 참조 관계 컬럼에 on delete cascade 옵션 추가

- 게시글 이미지 수정 관련 코드 추가
  - 게시글에 수정될 이미지의 수가 다를 경우 제대로 수정되지 않던 문제 해결
  - 수정하는 데이터에 이미지 값이 undefined가 아니라면 테이블에 존재하던 이미지를 삭제 후, 수정하며 업로드하는 이미지를 새롭게 insert

- 게시글 offset 관련 코드 수정
  - 기존에 query로 받던 limit값을 임의로 변경하지 못하도록 SQL문에 직접적으로 작성
  - SQL문에 직접적으로 계산식을 넣은 잘못된 offset을 대입하는 변수에서 미리 계산하도록 수정