### PR TITLE
Fix: 존재하지 않는 유저 로그인 시 예외 처리

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -5,7 +5,6 @@ import userDao from "../models/userDao"
 import { CreateUserDTO, UpdateUserDTO } from "../dto/userDto"
 import { BadRequestExceptions, keyError, PwMismatchError } from "../common/createError"
 import { SECRET_KEY, JavaScript_Key, REDIRECT_URI } from "../configs/keyConfig"
-import likeAndBookmarkDao from "../models/likeAndBookmarkDao";
 
 
 const userAvailableCheck = async (userData: object) => {
@@ -33,7 +32,10 @@ const signInUser = async (userData: CreateUserDTO) => {
   let token = ""
 
   const userIdPw = await userDao.getUserByAccount(userData);
-  console.log(userIdPw)
+  
+  if(userIdPw.length === 0) { throw new BadRequestExceptions("User_Not_Existed") }
+
+  else {
   const isPasswordCorrected = bcrypt.compareSync(userData.password, userIdPw[0].password);
 
   if (!isPasswordCorrected) { throw new PwMismatchError("Password_Mismatch") }
@@ -45,7 +47,7 @@ const signInUser = async (userData: CreateUserDTO) => {
   }
 
   return user;
-}
+}}
 
 
 // kakao


### PR DESCRIPTION
존재하지 않는 유저 로그인 시 예외 처리
  - 로그인할 때 유저 정보 조회 후 해당 값이 빈 배열일 때 진행되도록 분기 처리
  - 기존에 500 에러로 처리되던 문제를 400 BadRequestExceptions 으로 수정

Issue: #47