### PR TITLE
Feature: Swagger를 이용한 API 문서 추가(수정 예정)

### DIFF
--- a/modules/swagger.ts
+++ b/modules/swagger.ts
@@ -1,0 +1,21 @@
+import swaggerJSDoc from "swagger-jsdoc"
+
+const options = {
+  swaggerDefinition: {
+    openapi: "3.0.1",
+    info: {
+      version: "1.0.0",
+      title: "Witty API Docs with Swagger API",
+      description:
+        "트위터, 인스타그램 등의 SNS 서비스를 오마주한 Witty의 API 문서입니다.",
+    },
+    servers: [
+      {
+        url: "http://localhost:8000",
+      },
+    ],
+  },
+  apis: ["src/routes/*.ts"],
+}
+
+export const specs = swaggerJSDoc(options)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,8 @@
         "jsonwebtoken": "^8.5.1",
         "morgan": "^1.10.0",
         "mysql2": "^2.3.3",
-        "passport": "^0.6.0",
-        "passport-jwt": "^4.0.0",
-        "passport-local": "^1.0.0",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^4.6.0",
         "typeorm": "^0.3.10"
       },
       "devDependencies": {
@@ -29,11 +28,51 @@
         "@types/jsonwebtoken": "^8.5.9",
         "@types/morgan": "^1.9.3",
         "@types/node": "^18.11.9",
-        "@types/passport": "^1.0.11",
-        "@types/passport-jwt": "^3.0.7",
+        "@types/swagger-jsdoc": "^6.0.1",
+        "@types/swagger-ui-express": "^4.1.3",
         "nodemon": "^2.0.20",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.4"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -72,6 +111,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
@@ -156,6 +200,11 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
     "node_modules/@types/jsonwebtoken": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
@@ -186,36 +235,6 @@
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "devOptional": true
     },
-    "node_modules/@types/passport": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.11.tgz",
-      "integrity": "sha512-pz1cx9ptZvozyGKKKIPLcVDVHwae4hrH5d6g5J+DkMRRjR3cVETb4jMabhXAUbg3Ov7T22nFHEgaK2jj+5CBpw==",
-      "dev": true,
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
-    "node_modules/@types/passport-jwt": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-3.0.7.tgz",
-      "integrity": "sha512-qRQ4qlww1Yhs3IaioDKrsDNmKy6gLDLgFsGwpCnc2YqWovO2Oxu9yCQdWHMJafQ7UIuOba4C4/TNXcGkQfEjlQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/express": "*",
-        "@types/jsonwebtoken": "*",
-        "@types/passport-strategy": "*"
-      }
-    },
-    "node_modules/@types/passport-strategy": {
-      "version": "0.2.35",
-      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.35.tgz",
-      "integrity": "sha512-o5D19Jy2XPFoX2rKApykY15et3Apgax00RRLf0RUotPDUsYrQa7x4howLYr9El2mlUApHmCMv5CZ1IXqKFQ2+g==",
-      "dev": true,
-      "dependencies": {
-        "@types/express": "*",
-        "@types/passport": "*"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -236,6 +255,22 @@
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.1.tgz",
+      "integrity": "sha512-+MUpcbyxD528dECUBCEVm6abNuORdbuGjbrUdHDeAQ+rkPuo2a+L4N02WJHF3bonSSE6SJ3dUJwF2V6+cHnf0w==",
+      "dev": true
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/abbrev": {
@@ -508,6 +543,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -664,6 +704,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -800,6 +848,17 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -846,6 +905,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1321,6 +1388,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1330,6 +1402,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
@@ -1350,6 +1427,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -1653,6 +1735,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
+      "integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==",
+      "peer": true
+    },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -1679,51 +1767,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/passport": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
-      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
-      "dependencies": {
-        "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jaredhanson"
-      }
-    },
-    "node_modules/passport-jwt": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
-      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
-      "dependencies": {
-        "jsonwebtoken": "^8.2.0",
-        "passport-strategy": "^1.0.0"
-      }
-    },
-    "node_modules/passport-local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
-      "integrity": "sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==",
-      "dependencies": {
-        "passport-strategy": "1.x.x"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/passport-strategy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1736,11 +1779,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
-    },
-    "node_modules/pause": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -2025,6 +2063,74 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz",
+      "integrity": "sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.0.tgz",
+      "integrity": "sha512-ZxpQFp1JR2RF8Ar++CyJzEDdvufa08ujNUJgMVTMWPi86CuQeVdBtvaeO/ysrz6dJAYXf9kbVNhWD7JWocwqsA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.11.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
       }
     },
     "node_modules/thenify": {
@@ -2315,6 +2421,14 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true
     },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2377,6 +2491,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.6.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
@@ -2410,9 +2532,71 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     }
   },
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
+    },
+    "@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      }
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -2443,6 +2627,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@sqltools/formatter": {
       "version": "1.2.5",
@@ -2527,6 +2716,11 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
     "@types/jsonwebtoken": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
@@ -2557,36 +2751,6 @@
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "devOptional": true
     },
-    "@types/passport": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.11.tgz",
-      "integrity": "sha512-pz1cx9ptZvozyGKKKIPLcVDVHwae4hrH5d6g5J+DkMRRjR3cVETb4jMabhXAUbg3Ov7T22nFHEgaK2jj+5CBpw==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*"
-      }
-    },
-    "@types/passport-jwt": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-3.0.7.tgz",
-      "integrity": "sha512-qRQ4qlww1Yhs3IaioDKrsDNmKy6gLDLgFsGwpCnc2YqWovO2Oxu9yCQdWHMJafQ7UIuOba4C4/TNXcGkQfEjlQ==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*",
-        "@types/jsonwebtoken": "*",
-        "@types/passport-strategy": "*"
-      }
-    },
-    "@types/passport-strategy": {
-      "version": "0.2.35",
-      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.35.tgz",
-      "integrity": "sha512-o5D19Jy2XPFoX2rKApykY15et3Apgax00RRLf0RUotPDUsYrQa7x4howLYr9El2mlUApHmCMv5CZ1IXqKFQ2+g==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*",
-        "@types/passport": "*"
-      }
-    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -2607,6 +2771,22 @@
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/swagger-jsdoc": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.1.tgz",
+      "integrity": "sha512-+MUpcbyxD528dECUBCEVm6abNuORdbuGjbrUdHDeAQ+rkPuo2a+L4N02WJHF3bonSSE6SJ3dUJwF2V6+cHnf0w==",
+      "dev": true
+    },
+    "@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "abbrev": {
@@ -2804,6 +2984,11 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2919,6 +3104,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3008,6 +3198,14 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "devOptional": true
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "dotenv": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -3045,6 +3243,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -3389,6 +3592,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -3398,6 +3606,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -3418,6 +3631,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -3651,6 +3869,12 @@
         "wrappy": "1"
       }
     },
+    "openapi-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
+      "integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==",
+      "peer": true
+    },
     "parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -3676,38 +3900,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
-    "passport": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
-      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
-      "requires": {
-        "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
-      }
-    },
-    "passport-jwt": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
-      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
-      "requires": {
-        "jsonwebtoken": "^8.2.0",
-        "passport-strategy": "^1.0.0"
-      }
-    },
-    "passport-local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
-      "integrity": "sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==",
-      "requires": {
-        "passport-strategy": "1.x.x"
-      }
-    },
-    "passport-strategy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA=="
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3717,11 +3909,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
-    },
-    "pause": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -3946,6 +4133,55 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "requires": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "requires": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz",
+      "integrity": "sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA=="
+    },
+    "swagger-ui-express": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.0.tgz",
+      "integrity": "sha512-ZxpQFp1JR2RF8Ar++CyJzEDdvufa08ujNUJgMVTMWPi86CuQeVdBtvaeO/ysrz6dJAYXf9kbVNhWD7JWocwqsA==",
+      "requires": {
+        "swagger-ui-dist": ">=4.11.0"
+      }
+    },
     "thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -4092,6 +4328,11 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true
     },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4136,6 +4377,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="
+    },
     "yargs": {
       "version": "17.6.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
@@ -4160,6 +4406,25 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "devOptional": true
+    },
+    "z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "requires": {
+        "commander": "^9.4.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@types/jsonwebtoken": "^8.5.9",
     "@types/morgan": "^1.9.3",
     "@types/node": "^18.11.9",
+    "@types/swagger-jsdoc": "^6.0.1",
+    "@types/swagger-ui-express": "^4.1.3",
     "nodemon": "^2.0.20",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
@@ -40,6 +42,8 @@
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0",
     "mysql2": "^2.3.3",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.6.0",
     "typeorm": "^0.3.10"
   }
 }

--- a/src/routes/apiDocs.ts
+++ b/src/routes/apiDocs.ts
@@ -1,0 +1,697 @@
+// API 명세서
+/**
+ * @swagger
+ * paths:
+ *  /users/duplication:
+ *    post:
+ *       summary: 이메일 혹은 계정 중복 체크
+ *       tags:
+ *        - Users
+ *       description: 회원 가입할 때 이메일이나 계정이 기존 회원과 중복되는지 체크
+ *       produces:
+ *        - application/json
+ *       requestBody:
+ *        description: email 혹은 account 둘 중 하나 입력
+ *        content:
+ *          application/json:
+ *            schema:
+ *              required:
+ *                - email(account)
+ *              properties:
+ *                email(account):
+ *                  type: string
+ *                  example: testing2@gmail.com(Test2test)
+ *       responses:
+ *        '200':
+ *          description: 회원 가입 성공
+ *          content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  {"message": "Available"}
+ *        '404':
+ *          description: 키 값 미입력
+ *          content:
+ *             application/json:
+ *              schema:
+ *                example:                         
+ *                  {"err": "Not_Found_Key"}
+ *        '409':
+ *          description: 중복 값 오류
+ *          content:
+ *             application/json:
+ *              schema:
+ *                example:                         
+ *                  {"err": "Duplicate_Error"}
+ * 
+ * 
+ *  /users/signup:
+ *    post:
+ *       summary: 회원 가입
+ *       tags:
+ *        - Users
+ *       description: 닉네임, 계정, 이메일, 비밀번호를 입력하여 회원 가입
+ *       produces:
+ *        - application/json
+ *       parameters:
+ *         - in: body
+ *           name: input
+ *           type: string
+ *           description : "account, email, password, nickname"
+ *           required: true
+ *       requestBody:
+ *        description: 각각 input에 account, email, password, nickname 입력
+ *        content:
+ *          application/json:
+ *            schema:
+ *              required:
+ *                - account
+ *                - email
+ *                - password
+ *                - nickname
+ *              type: object
+ *              properties:
+ *                account:
+ *                  type: string
+ *                  example: Test2test
+ *                email:
+ *                  type: string
+ *                  example: testing2@gmail.com
+ *                password:
+ *                  type: string
+ *                  example: Test2test2!
+ *                nickname:
+ *                  type: string
+ *                  example: test2
+ *       responses:
+ *        '201':
+ *          description: 회원 가입 성공
+ *          content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  {"message": "User_Created"}
+ *        '400':
+ *          description: 정규표현식 오류
+ *          content:
+ *             application/json:
+ *              schema:
+ *                example:                         
+ *                  {"err": "RegExp_Error"}
+ *
+ * 
+ *  /users/signin:
+ *    post:
+ *      summary: 로그인
+ *      tags:
+ *      - Users
+ *      description: account와 password를 입력하여 로그인
+ *      produces:
+ *      - application/json
+ *      requestBody:
+ *        description: account, password 입력하여 로그인
+ *        content:
+ *          application/json:
+ *            schema:
+ *              required:
+ *                - account
+ *                - password
+ *              type: object
+ *              properties:
+ *                account:
+ *                  type: string
+ *                  example: Test2test
+ *                password:
+ *                  type: string
+ *                  example: Test2test2!
+ *      responses:
+ *        '200':
+ *          description: 로그인 성공 메시지와 유저 nickname, token 전달 
+ *          content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  {"message": "Login_Success", "result": {"nickname": "test2", "token": "eyJhb..."}}
+ *        '400-(1)':
+ *          description: 존재하지 않는 유저
+ *          content:
+ *             application/json:
+ *              schema:
+ *                example:                         
+ *                  {"err": "User_Not_Existed"}
+ *        '400-(2)':
+ *          description: 비밀번호 불일치
+ *          content:
+ *             application/json:
+ *              schema:
+ *                example:                         
+ *                  {"err": "Password_Mismatch"}
+ * 
+ * 
+ *  /users/my:
+ *    get:
+ *      summary: 마이페이지
+ *      tags:
+ *      - Users
+ *      description: 마이페이지의 메인으로 유저 idx, account, nickname 조회
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *      responses:
+ *       '200':
+ *         description: 마이 페이지 조회 성공, 유저 idx, account, nickname 전달
+ * 
+ *    delete:
+ *      summary: 회원 탈퇴
+ *      tags:
+ *      - Users
+ *      description: 회원 탈퇴
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *      responses:
+ *       '200':
+ *         description: 회원 탈퇴 성공 메시지 전달
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  {"message": "Withdrow_Success"}
+ *     
+ * 
+ *  /users/my/posts:
+ *    get:
+ *      summary: 마이페이지 내 게시글 목록
+ *      tags:
+ *      - Users
+ *      description: 내가 작성한 게시글 전체 목록 조회
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *      responses:
+ *       '200':
+ *         description: 내 게시글 전체 목록 전달
+ * 
+ * 
+ *  /users/my/bookmarks:
+ *    get:
+ *      summary: 마이페이지 내 북마크 목록
+ *      tags:
+ *      - Users
+ *      description: 내가 북마크한 게시글 전체 목록 조회
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *      responses:
+ *       '200':
+ *         description: 내가 북마크한 전체 게시글 목록 전달
+ * 
+ * 
+ *  /users/my/bookmarks/{post_id}:
+ *    patch:
+ *      summary: 마이페이지 내 북마크 목록 수정
+ *      tags:
+ *      - Users
+ *      description: 내 북마크 전체 목록 중 특정 게시글의 북마크 취소
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *        - in: path
+ *          name: postId
+ *          required: true
+ *          type: string
+ *          description : 북마크 취소 할 게시글의 고유키
+ *      responses:
+ *       '200':
+ *         description: 목록 수정 후 최신 북마크 목록 전달
+ * 
+ * 
+ *  /users/my/name:
+ *    patch:
+ *      summary: 이용자 닉네임 수정
+ *      tags:
+ *      - Users
+ *      description: 닉네임 수정
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *      requestBody:
+ *        description: 수정할 nickname 입력
+ *        content:
+ *          application/json:
+ *            schema:
+ *              required:
+ *                - nickname
+ *              type: object
+ *              properties:
+ *                nickname:
+ *                  type: string
+ *                  example: 안녕하세요
+ *      responses:
+ *       '200':
+ *         description: 닉네임 수정 완료 메시지 전달
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  {"message": "Nickname_Updated"}
+ * 
+ * 
+ * 
+ * 
+ * 
+ * 
+ * 
+ * 
+ *  /posts:
+ *    post:
+ *      summary: 새 게시글 작성
+ *      tags:
+ *      - Posts
+ *      description: 새 게시글 작성
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *      requestBody:
+ *        description: 작성할 게시글의 category, content, images 입력
+ *        content:
+ *          application/json:
+ *            schema:
+ *              required:
+ *                - category
+ *                - content
+ *                - images
+ *              type: object
+ *              properties:
+ *                category:
+ *                  type: array
+ *                  items:
+ *                    type: string
+ *                    example: 오늘잡담
+ *                images:
+ *                  type: array
+ *                  items:
+ *                    type: string
+ *                    example: imageURLs
+ *                content:
+ *                  type: string
+ *                  example: 작성할 내용을 입력해주세요.
+ *      responses:
+ *       '201':
+ *         description: 새 게시글 작성 완료 메시지 전달
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  {"message": "Post_Created"}
+ * 
+ *
+ *    get:
+ *      summary: 전체 게시글 목록 조회
+ *      tags:
+ *      - Posts
+ *      description: 전체 게시글 목록 조회
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          type: string
+ *          description : 로그인 시 발급된 토큰(optional)
+ *        - in: query
+ *          name: offset
+ *          required: true
+ *          schema:
+ *            type: string
+ *          description : 스크롤링을 위한 offset값 (0, 1, 2 ...)
+ *      responses:
+ *       '200':
+ *         description: 전체 게시글의 정보 전달. 토큰 입력 시 is_marked, is_liked, is_owner 정보도 전달.
+ * 
+ * 
+ *  /posts/{post_id}:
+ *    get:
+ *      summary: 특정 게시글 상세 정보 조회
+ *      tags:
+ *      - Posts
+ *      description: 특정 게시글 상세 정보 조회
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          type: string
+ *          description : 로그인 시 발급된 토큰(optional)
+ *        - in: path
+ *          name: postId
+ *          required: true
+ *          type: string
+ *          description : 특정 게시글의 고유키
+ *      responses:
+ *       '200':
+ *         description: 특정 게시글 상세 정보 전달. 토큰 입력 시 특정 게시글에 대한 is_marked, is_liked, is_owner 정보도 전달.
+ * 
+ *    delete:
+ *      summary: 특정 게시글 삭제
+ *      tags:
+ *      - Posts
+ *      description: 특정 게시글 삭제
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *        - in: path
+ *          name: postId
+ *          required: true
+ *          type: string
+ *          description : 특정 게시글의 고유키
+ *      responses:
+ *       '204':
+ *         description: 메시지 전달 없음
+ * 
+ * 
+ * 
+ *  /posts/update/{post_id}:
+ *    get:
+ *      summary: 수정할 특정 게시글의 기존 정보 조회
+ *      tags:
+ *      - Posts
+ *      description: 수정할 게시글의 기존 정보 조회
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *        - in: path
+ *          name: postId
+ *          required: true
+ *          type: string
+ *          description : 수정할 게시글의 고유키
+ *      responses:
+ *       '200':
+ *         description: 수정할 특정 게시글의 idx, category, content, file(이미지들) 값 전달
+ * 
+ *    patch:
+ *      summary: 특정 게시글의 수정
+ *      tags:
+ *      - Posts
+ *      description: 특정 게시글을 입력한 내용으로 수정
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *        - in: path
+ *          name: postId
+ *          required: true
+ *          type: string
+ *          description : 수정할 게시글의 고유키
+ *      requestBody:
+ *        description: 수정할 내용 입력
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                category:
+ *                  type: array
+ *                  items:
+ *                    type: string
+ *                    example: 오늘잡담(optionaal)
+ *                images:
+ *                  type: array
+ *                  items:
+ *                    type: string
+ *                    example: imageURLs(optional)
+ *                content:
+ *                  type: string
+ *                  example: 수정할 내용을 입력해주세요.(optional)
+ *      responses:
+ *       '200':
+ *         description: 수정 완료 메시지 전달
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  {"message": "Update_Success"}
+ * 
+ * 
+ *  /posts/{post_id}/bookmark:
+ *    patch:
+ *      summary: 특정 게시글 북마크
+ *      tags:
+ *      - Posts
+ *      description: 특정 게시글 북마크 누르기 / 취소
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *        - in: path
+ *          name: postId
+ *          required: true
+ *          type: string
+ *          description : 북마크 누를 게시글의 고유키
+ *      responses:
+ *       '200':
+ *         description: 현 이용자의 게시글 북마크 상태 값
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  { "is_marked": 1 }
+ * 
+ * 
+ *  /posts/{post_id}/like:
+ *    patch:
+ *      summary: 특정 게시글 좋아요
+ *      tags:
+ *      - Posts
+ *      description: 특정 게시글에 좋아요 누르기 / 취소
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *        - in: path
+ *          name: postId
+ *          required: true
+ *          type: string
+ *          description : 좋아요 누를 게시글의 고유키
+ *      responses:
+ *       '200':
+ *         description: 현 이용자의 게시글 좋아요 상태 값 및 게시글의 총 좋아요 갯수 전달
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  { "is_liked": 1, "count_likes": 1 }
+ * 
+ * 
+ * 
+ * 
+ * 
+ * 
+ *  /posts/{post_id}/comment:
+ *    post:
+ *      summary: 새 댓글 작성
+ *      tags:
+ *      - Posts
+ *      description: 특정 게시글에 새 댓글 작성
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *        - in: path
+ *          name: postId
+ *          required: true
+ *          type: string
+ *          description : 댓글 작성할 게시글의 고유키
+ *      responses:
+ *       '201':
+ *         description: 새 댓글 작성 완료 메시지 전달
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  {"message": "Comment_Created"}
+ * 
+ * 
+ *  /posts/{post_id}/{comment_id}:
+ *    patch:
+ *      summary: 게시글의 댓글 삭제
+ *      tags:
+ *      - Posts
+ *      description: 특정 게시글의 특정 댓글 삭제
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *        - in: path
+ *          name: postId
+ *          required: true
+ *          type: string
+ *          description : 삭제할 댓글이 작성된 게시글의 고유키
+ *        - in: path
+ *          name: commentId
+ *          required: true
+ *          type: string
+ *          description : 삭제할 댓글의 고유키
+ *      responses:
+ *       '200':
+ *         description: 댓글 삭제 후 게시글의 댓글 갱신된 목록 조회
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  [{"id": 1, "comment": "댓글 작성", "user_id": 1, "is_liked": null, "nickname": "test2", "created_at": "2023-01-27 18:10:39.708213", "count_likes": null, "is_owner": true}]
+ * 
+ * 
+ * 
+ * 
+ *  /comments/{comment_id}/like:
+ *    patch:
+ *      summary: 특정 댓글 좋아요
+ *      tags:
+ *      - Comments
+ *      description: 특정 댓글 좋아요 누르기 / 취소
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          required: true
+ *          type: string
+ *          description : 로그인 시 발급된 토큰
+ *        - in: path
+ *          name: commentId
+ *          required: true
+ *          type: string
+ *          description : 좋아요 누를 댓글의 고유키
+ *      responses:
+ *       '200':
+ *         description: 현 이용자의 해당 댓글 좋아요 상태 값 및 댓글의 총 좋아요 갯수 전달
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  { "is_liked": 1, "count_likes": 1 }
+ *                  
+ * 
+ *
+ * 
+ *  
+ * 
+ * 
+ * 
+ *  /search/like:
+ *    patch:
+ *      summary: 검색 메인 페이지, 게시글 인기순 조회
+ *      tags:
+ *      - Search
+ *      description: 검색 메인 페이지에 표시되는 게시글 인기순(좋아요 순) 12개 조회
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          type: string
+ *          description : 로그인 시 발급된 토큰(optional)
+ *      responses:
+ *       '200':
+ *         description: 좋아요 순으로 조회된 12개의 게시글 정보 전달
+ *         content:
+ *            application/json:
+ *             schema:
+ *                example:
+ *                  { "is_liked": 1, "count_likes": 1 } 
+ * 
+ * 
+ *  /search:
+ *    get:
+ *      summary: 키워드 혹은 카테고리 검색
+ *      tags:
+ *      - Search
+ *      description: 키워드(q) 혹은 카테고리(category) 검색
+ *      produces:
+ *      - application/json
+ *      parameters:
+ *        - in: header
+ *          name: token
+ *          type: string
+ *          description : 로그인 시 발급된 토큰(optional)
+ *        - in: qeury
+ *          name: q
+ *          type: string
+ *          description : 검색할 키워드
+ *        - in: query
+ *          name: category
+ *          type: string
+ *          description : 검색할 카테고리
+ *      responses:
+ *       '200':
+ *         description: 검색된 게시글 정보 전달
+ * 
+ * 
+ *     
+ *
+ */

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,9 +3,12 @@ import userRouter from "./usersRoute"
 import postRouter from "./postsRoute"
 import commentRouter from "./commentsRoute"
 import searchRouter from "./searchRoute"
+import swaggerUi from "swagger-ui-express"
+import { specs } from "../../modules/swagger"
 
 const router = express.Router()
 
+router.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs));
 router.use('/users', userRouter)
 router.use('/posts', postRouter)
 router.use('/comments', commentRouter)


### PR DESCRIPTION
Swagger를 이용한 API 문서 추가(수정 예정)
  - swagger API 문서를 구현하기 위한 swagger-ui-express, swagger-jsdoc 설치
  - 설정 파일(modules/swagger.ts) 작성 및 JSON 형태의 specs export
    - swagger API의 info, servers 등
    - swagger.ts와 routes의 파일을 연동하는 apis option 포함
  - routes/index.ts에 '/api-docs' url 추가 및 specs setup
  - routes/apiDocs.ts에 API 문서를 jsdoc 형태로 작성

Issue: #49