### PR TITLE
Fix: build, start 과정에서 생기는 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "witty",
   "version": "1.0.0",
   "description": "SNS를 모티브로 하는 Toy Project",
-  "main": "index.js",
+  "main": "./dist/src/server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon dist/server.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    // "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -101,7 +101,8 @@
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "modules/**/*"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
build 과정에서 생기는 오류 수정
  - modules 디렉토리를 포함하기 위해 tsconfig의 include field 수정

start 과정에서 생기는 오류 수정
  - Error: Cannot find module 이 발생
  - 즉, package.json의 main field를 변경하지 않아 디폴트로 설정되어있던 index.js를 발견하지 못하던 오류 발생
  - build 이후 생성된 dist/server.js 상대경로로 main field 수정

Issue: #53