### PR TITLE
Fix: 토큰 에러 발생시 에러 메시지 반환 문제, 인증인가처리 수정

### DIFF
--- a/src/middlewares/authorization.ts
+++ b/src/middlewares/authorization.ts
@@ -1,15 +1,17 @@
 import { NextFunction, Request, Response } from "express"
 import jwt from "jsonwebtoken"
-import { BadRequestExceptions, NotFoundError, UnauthorizedExecption } from "../common/createError";
+import { NotFoundError } from "../common/createError";
 import { getUserExistsById } from "../models/userDao"
 import { SECRET_KEY } from "../configs/keyConfig"
-
 
 
 const validateToken = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const access_token = req.headers['authorization'];
-    if (!access_token) throw new UnauthorizedExecption("Token_Not_Provided")
+    if (!access_token) {
+      res.status(401).json({ err: "Not_Provided" });
+      return;
+    }
 
     const userId = jwt.verify(access_token, SECRET_KEY);
     const value = Object.values(userId)
@@ -20,34 +22,12 @@ const validateToken = async (req: Request, res: Response, next: NextFunction) =>
     req.body.foundUser = value[0];
     next();
 
-  } catch (error) {
-    console.log(error)
-    throw new BadRequestExceptions("Invalid_Token")
-  }
-};
-
-// 애초에 로그인해야 서비스 이용이 가능하므로 함수 하나로 통일해도 될 듯. 또한 인증인가를 둘러싸는 asnycWrap도 고민할 것. 현재 400, 401 에러처리가 제대로 안됨
-const validateTokenBycondition = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const access_token = req.headers['authorization'];
-    if(access_token) {
-      const userId = jwt.verify(access_token, SECRET_KEY);
-      const value = Object.values(userId)
-      
-      const [foundUser] = await getUserExistsById(value[0]);
-      if(!+Object.values(foundUser)[0]) throw new NotFoundError("User_Not_Found");
-      
-      req.body.foundUser = value[0];
-    } else if (!access_token) { req.body.foundUser = null; }
-
-    next();
-
-  } catch (error) {
-    console.log(error)
-    throw new BadRequestExceptions("Invalid_Token")
+  } catch (err: any) {
+    console.log(err)
+    res.status(400).json({ err: "INVALID_TOKEN" });
   }
 };
 
 
 
-export { validateToken, validateTokenBycondition };
+export { validateToken };

--- a/src/routes/postsRoute.ts
+++ b/src/routes/postsRoute.ts
@@ -1,13 +1,13 @@
 import express from "express"
 import postController from "../controllers/postController"
 import commentController from "../controllers/commentController"
-import { validateToken, validateTokenBycondition } from "../middlewares/authorization"
+import { validateToken } from "../middlewares/authorization"
 
 const router = express.Router()
 
 router.post("", validateToken, postController.createPost)
-router.get("", validateTokenBycondition, postController.getAllPosts)
-router.get("/:post_id", validateTokenBycondition, postController.getPostById)
+router.get("", validateToken, postController.getAllPosts)
+router.get("/:post_id", validateToken, postController.getPostById)
 router.get("/update/:post_id", validateToken, postController.getDatasBeforeUpdatePost)
 router.patch("/update/:post_id", validateToken, postController.updatePost)
 router.delete("/:post_id", validateToken, postController.deletePost)

--- a/src/routes/searchRoute.ts
+++ b/src/routes/searchRoute.ts
@@ -1,12 +1,12 @@
 import express from "express"
 import searchController from "../controllers/searchController"
-import { validateTokenBycondition } from "../middlewares/authorization"
+import { validateToken } from "../middlewares/authorization"
 
 const router = express.Router()
 
-router.get("", validateTokenBycondition, searchController.getPostByKeyword)
+router.get("", validateToken, searchController.getPostByKeyword)
 router.get("/user", searchController.getUserByKeyword)
-router.get("/category", validateTokenBycondition, searchController.getCategoryByKeyword)
-router.get("/like", validateTokenBycondition, searchController.getPostsByLiked)
+router.get("/category", validateToken, searchController.getCategoryByKeyword)
+router.get("/like", validateToken, searchController.getPostsByLiked)
 
 export default router


### PR DESCRIPTION
토큰 에러 발생 시 에러 메시지 반환 문제 수정
  - authorization 미들웨어에서 throw한 에러 메시지를 프론트로 전달하지 못해 발생하는 오류
  - 미들웨어의 validateToken 함수에 throw new Error가 아닌 res.json을 사용하도록 수정

조건부 인증, 인가 처리 함수 삭제
  - 이 서비스는 첫 화면의 로그인 후 이용하도록 기획되어 있으므로 조건부 함수가 필요하지 않음
  - route에서 인증 인가 처리 되었던 부분의 함수명 수정

Issue: